### PR TITLE
added monitoring tag and definition

### DIFF
--- a/blog/cloud-readiness.md
+++ b/blog/cloud-readiness.md
@@ -6,6 +6,7 @@ tags:
   - business
   - aws
   - azure
+  - monitoring
 date: 2024-11-17
 
 ---

--- a/blog/network-blame-game.md
+++ b/blog/network-blame-game.md
@@ -5,6 +5,7 @@ tags:
   - opinion
   - business
   - networks
+  - monitoring
 date: 2024-11-17
 
 ---

--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -163,3 +163,8 @@ sdwan:
   label: 'SDWAN'
   permalink: '/sdwan'
   description: 'Software-Defined Wide Area Networking concepts, implementations, and best practices'
+
+monitoring:
+  label: 'Monitoring'
+  permalink: '/monitoring'
+  description: 'System and network monitoring techniques, tools, and best practices'


### PR DESCRIPTION
This pull request adds a new "monitoring" tag to the blog system and applies it to relevant articles. The main changes include updating the tag definitions and tagging appropriate blog posts.

Tag management:

* Added a new `monitoring` tag to `blog/tags.yml`, including its label, permalink, and description.

Blog post updates:

* Added the `monitoring` tag to the `blog/cloud-readiness.md` article.
* Added the `monitoring` tag to the `blog/network-blame-game.md` article.