### PR TITLE
Egress IP updated with new info about two LBs

### DIFF
--- a/blog/egress-ip-decision-tree-updated.md
+++ b/blog/egress-ip-decision-tree-updated.md
@@ -21,7 +21,7 @@ It's taken from the [default outbound internet access](https://learn.microsoft.c
 
 The question I had this time was around the Load Balancer. Again the NAT gateway takes precedence over the Load Balancer's outbound rules, and you can't have a public loadbalancer coexisting with a PIP on a VM so those are all pretty predictable. But what happens if you have a public load balancer with two sets of outbound rules, on two different front-end IP configurations, and with two different backend pools? Which outbound IP gets used then?
 
-> This is quite a niche scenatio and unique to the public load balancer. You can't have two different Public IPs on the same IP Configuration, and you can't have two different NAT Gateways on the same subnet so this is really only relevant to public load balancers.
+> This is quite a niche scenario and unique to the public load balancer. You can't have two different Public IPs on the same IP Configuration, and you can't have two different NAT Gateways on the same subnet so this is really only relevant to public load balancers.
 
 I'll not bore you with the details of why I had to find this out, that's for another time, but suffice to say it was a real-world scenario (although using private load balancers in that situation). The answer is that the outbound IP used is determined by which backend pool the VM is added to first. This means that if you have multiple backend pools and you want to add a new VM to them you need to be careful to preserve the order in which the VM is added to the backend pools, otherwise you may inadvertently change the egress IP used for outbound internet access.
 


### PR DESCRIPTION
This pull request adds a new blog post, `egress-ip-decision-tree-updated.md`, which documents findings about Azure public load balancer outbound IP selection when multiple backend pools and frontend IP configurations are involved.

Content addition:

* Added a new blog post explaining how the outbound IP is chosen for Azure public load balancers with multiple backend pools and frontend IPs, highlighting that the egress IP is determined by the first backend pool a VM is added to—a detail not found in official documentation.