### PR TITLE
chore: bump lodash-es to 4.17.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@iconify-json/logos": "^1.2.9",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
-        "lodash-es": "4.17.23",
+        "lodash-es": "^4.17.23",
         "prism-react-renderer": "^2.3.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@iconify-json/logos": "^1.2.9",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
-    "lodash-es": "4.17.23",
+    "lodash-es": "^4.17.23",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"


### PR DESCRIPTION
Bumps lodash-es to 4.17.23 to address CVE-2025-13465 (moderate) detected in package-lock.json.