### PR TITLE
Blog/bgp enterprise cloud connectivity

### DIFF
--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -167,23 +167,24 @@ flowchart LR
 
 Why this matters for the cloud journey: this is the closest mental model to Direct Connect/ExpressRoute peering.
 
-### Pattern B (sidebar): CE–CE peering over MPLS (customer edges peer with each other)
+:::note Pattern B: CE–CE peering over MPLS (customer edges peer with each other)
 
-> This is **not the typical MPLS model**; most MPLS WANs are built as a many-to-many L3VPN where you peer to the provider, and the provider does the route distribution.
->
-> That said, I _have_ seen real-world deployments where the MPLS network is treated as **a transport underlay**, and the **customer edge routers form BGP adjacencies with each other**.
->
-> What it looks like from the customer’s point of view:
->
-> - Site A CE has BGP neighbours that are _other customer CEs_.
-> - The provider ASN may not appear in the AS_PATH (because the provider isn’t acting as a BGP hop in your control plane).
->
-> What has to be true for it to work:
->
-> - The provider must provide **IP reachability between CEs** (it’s effectively giving you a routed any-to-any service), and
-> - the provider is **not** doing your inter-site route exchange for you; _your BGP_ is.
->
-> This pattern is conceptually closer to “running your own WAN overlay” than to classic managed MPLS L3VPN routing.
+This is **not the typical MPLS model**; most MPLS WANs are built as a many-to-many L3VPN where you peer to the provider, and the provider does the route distribution.
+
+That said, I _have_ seen real-world deployments where the MPLS network is treated as **a transport underlay**, and the **customer edge routers form BGP adjacencies with each other**.
+
+What it looks like from the customer's point of view:
+
+- Site A CE has BGP neighbours that are _other customer CEs_.
+- The provider ASN may not appear in the AS_PATH (because the provider isn't acting as a BGP hop in your control plane).
+
+What has to be true for it to work:
+
+- The provider must provide **IP reachability between CEs** (it's effectively giving you a routed any-to-any service), and
+- the provider is **not** doing your inter-site route exchange for you; _your BGP_ is.
+
+This pattern is conceptually closer to "running your own WAN overlay" than to classic managed MPLS L3VPN routing.
+:::
 
 ### ASNs in MPLS enterprise designs
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -418,6 +418,9 @@ A few practical notes:
 ## TODO: diagrams
 - Add **Mermaid diagrams** for each architectural example/pattern in this post (MPLS patterns, dual circuits, CNF designs, etc.).
 
+## TODO: style pass
+- Replace **em dashes (—)** with commas or semicolons where appropriate.
+
 ## 8) Influencing inbound traffic (enterprise reality)
 
 Inbound is where BGP stops feeling like “routing” and starts feeling like diplomacy.

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -214,14 +214,72 @@ That’s why a lot of BGP guidance boils down to:
 
 ## 5) Route advertisement basics (what you advertise and why)
 
+This is where most real-world BGP outages come from.
+Not because someone misunderstood the BGP decision process — but because someone advertised (or accepted) more routes than they intended.
+
 ### “Less is more”
-(TODO)
+
+At an enterprise edge, you almost always want to:
+- advertise **only the prefixes you genuinely own and intend to be reachable**, and
+- accept **only the prefixes you actually need**.
+
+Everything else is just future-you doing incident response.
+
+Practically that means:
+- explicit prefix-lists for what you originate
+- route-policy that rejects “surprises” by default
+- max-prefix limits (we’ll cover these in the safety rails section)
+
+### Private routes vs public routes (both exist in the cloud world)
+
+Most people start with **private** connectivity:
+- you advertise RFC1918 (or your internal private space) towards the cloud,
+- you receive cloud private prefixes back,
+- and you use that for VNet/VPC reachability.
+
+But both Azure and AWS also have **public peering-style** options where you can exchange **public routes** over the dedicated circuit:
+
+- **Azure ExpressRoute**: *Microsoft peering* (public services over the Microsoft backbone)
+- **AWS Direct Connect**: *public VIF* (public AWS services over the DX)
+
+Why you’d do it:
+- predictable latency and jitter vs the internet
+- avoid hairpinning through generic internet egress
+- improve the path to cloud SaaS / public endpoints where it matters
+
+> Sidebar: public peering doesn’t magically make the services private.
+>
+> You’re still reaching public IPs. You’re just reaching them over a different transport.
+> The security model (identity, TLS, authz) still matters.
 
 ### Summarisation (and the sharp edges)
-(TODO)
+
+Summarisation is attractive because it:
+- reduces route table size
+- can make failover faster/cleaner
+- and is easier to reason about
+
+But it has sharp edges:
+- you can accidentally blackhole traffic if you summarise a block that isn’t fully reachable in all failure modes
+- you can lose useful specificity for traffic engineering (more-specifics win)
+
+A pragmatic approach is:
+- summarise where it’s *structurally true* (e.g., you really do own that block end-to-end),
+- keep de-aggregation for the cases where you need it deliberately (and document why).
 
 ### Defaults
-(TODO)
+
+Default routes are a great tool when used intentionally.
+
+- In small branch designs, a default can be exactly what you want: “send everything to the core.”
+- At a cloud edge, a default can be dangerous if it causes:
+  - accidental internet breakout where you didn’t intend it, or
+  - asymmetric paths that make troubleshooting miserable.
+
+If you use defaults, treat them like any other route:
+- filter them explicitly
+- set their preference intentionally
+- test the failure mode (what happens when the preferred exit disappears?)
 
 ## 6) BGP path selection (the bits you actually use)
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -1,0 +1,159 @@
+---
+title: "BGP for Enterprise Cloud Connectivity"
+authors: simonpainter
+tags:
+  - networks
+  - bgp
+  - cloud
+  - azure
+  - aws
+date: 2026-03-15
+draft: true
+---
+
+BGP is the control plane that makes Direct Connect and ExpressRoute work.
+
+If you only ever touched BGP at an MPLS edge, you can still run successful cloud connectivity — but you need a better mental model of **what BGP is doing**, **how attributes affect path selection**, and **which knobs actually influence inbound vs outbound**.
+
+<!--truncate-->
+
+## 1) What BGP is (in one page)
+
+BGP is a *path-vector* routing protocol. You don’t “discover the best path” by calculating the shortest path through a topology (like you do with link-state protocols). Instead, you **learn candidate paths** via advertisements, then you **select** between them using a predictable decision process.
+
+BGP is also **policy-first**. It’s designed for environments where “best” isn’t purely a function of link cost; it’s driven by *business relationships*, *operational preferences*, and *intent*.
+
+> Sidebar: “BGP isn’t an IGP”… except when it is.
+>
+> In most enterprise networks, BGP isn’t used as an IGP. But at very large scale (I’ve seen this first-hand at Walmart), some organisations do run BGP internally because the scaling and operational trade-offs can work out better than running a giant link-state domain.
+>
+> If you want the deeper reasoning: I wrote about OSPF scaling constraints and why BGP scales differently here:
+> https://www.simonpainter.com/dijkstra-ospf/
+
+## 2) eBGP vs iBGP (what matters at the cloud edge)
+
+### eBGP
+(TODO: definition + why eBGP is what you typically run to providers/cloud)
+
+### iBGP
+(TODO: definition + why iBGP design suddenly matters once you have multiple edges/CNFs)
+
+### Why you care
+(TODO)
+
+## 3) Where enterprise engineers have seen BGP before: MPLS WAN patterns
+
+### Managed CEs (you might never have seen the BGP config)
+(TODO)
+
+### Common MPLS patterns
+
+#### PE/CE eBGP (provider AS visible)
+(TODO)
+
+#### CE–CE style eBGP (provider AS not visible)
+(TODO: explain the concept and what it implies; provider carries/redistributes customer routes internally)
+
+### ASNs in MPLS enterprise designs
+
+#### Per-site ASNs
+(TODO)
+
+#### Single ASN across all sites (and why private-AS stripping matters)
+(TODO: explain why a route from site A reaches site B, gets dropped if B sees its own AS in AS_PATH)
+
+## 4) Peering relationships in enterprise cloud connectivity
+
+(TODO: on-prem edge ↔ exchange/provider ↔ cloud; private vs public ASN realities)
+
+## 5) Route advertisement basics (what you advertise and why)
+
+### “Less is more”
+(TODO)
+
+### Summarisation (and the sharp edges)
+(TODO)
+
+### Defaults
+(TODO)
+
+## 6) BGP path selection (the bits you actually use)
+
+(TODO: high-level decision flow — keep it practical and focus on attributes we’ll touch later)
+
+## 7) Influencing outbound traffic (enterprise reality)
+
+### LOCAL_PREF (the clean internal lever)
+(TODO)
+
+### IOS-XE example (LOCAL_PREF outbound preference)
+```ios
+! TODO
+```
+
+### JunOS example (LOCAL_PREF outbound preference)
+```junos
+# TODO
+```
+
+## 8) Influencing inbound traffic (enterprise reality)
+
+### Why inbound is harder
+(TODO: you’re asking someone else to choose differently)
+
+### AS_PATH prepending
+(TODO)
+
+### MED (when it’s honoured, and why it doesn’t travel)
+(TODO)
+
+### Communities (conceptual)
+BGP communities are one of the most useful “provider-supported knobs”, but they’re still *influence*, not control.
+
+I’ve written a more detailed comparison of how Azure and AWS use communities here:
+https://www.simonpainter.com/community-comparison/
+
+## 9) Communities (the provider-supported knobs)
+
+(TODO: keep conceptual; point to AWS/Azure docs and the comparison post above)
+
+## 10) Cloud exchange / carrier neutral facility (CNF) patterns
+
+A cloud exchange is typically a **carrier neutral facility (CNF)** where you can aggregate:
+- cloud provider connectivity (ExpressRoute / Direct Connect)
+- WAN connectivity (MPLS / SD-WAN)
+
+Assumption for the examples in this post:
+- you host **your own routers** in the exchange, and
+- the exchange provides **L2** to each cloud peer (so you run BGP directly with the cloud/provider routers).
+
+### Two-CNF diversity and ASN choices
+
+#### Option A: single ASN across both CNFs
+(TODO: explain path selection options)
+
+#### Option B: dual private ASNs (one per CNF)
+(TODO: explain why LOCAL_PREF and MED are AS-local / limited; why prepend is downstream-visible)
+
+## 11) Safety rails (the section that saves outages)
+
+### Prefix-lists / route filtering
+(TODO)
+
+### Max-prefix
+(TODO)
+
+### Route refresh / soft reconfig basics
+(TODO)
+
+## 12) Cloud specifics (light touch)
+
+### What’s different for DX/ER vs MPLS peering
+(TODO)
+
+### Route Server (brief pointer)
+(TODO: link to existing posts)
+
+## Conclusion
+
+(TODO)

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -255,6 +255,18 @@ flowchart LR
 
 On the enterprise side, you then need to decide how those routes get back into the rest of your network. That usually means iBGP to a core pair or route reflectors, or redistribution into an IGP (with all the caveats that implies).
 
+> ExpressRoute BGP essentials
+>
+> Microsoft Learn content about ExpressRoute often talks about “peerings” and “routing domains” without emphasising the mechanism. ExpressRoute is, in practice, delivered via redundant eBGP sessions.
+>
+> Each peering (Private peering, and Microsoft peering) is delivered via a pair of independent eBGP sessions. If you exceed prefix limits, the default behaviour is for the BGP session to be terminated, which is a hard failure mode and a good reason to monitor prefix counts.
+>
+> Microsoft-side BGP timers are fixed (keepalive and hold), so fast failover is normally achieved with BFD, which is enabled by default on Microsoft’s side, but must be configured on your CPE.
+>
+> Filtering is primarily your responsibility on the on-prem edge. Azure UDRs are static and not part of BGP advertisement. On Microsoft peering specifically, “no routes” is often explained by a missing route filter.
+>
+> References: circuit peerings and BGP behaviour (<https://learn.microsoft.com/en-us/azure/expressroute/expressroute-circuit-peerings>), ExpressRoute FAQs (<https://learn.microsoft.com/en-us/azure/expressroute/expressroute-faqs>), resiliency guidance (<https://learn.microsoft.com/en-us/azure/expressroute/design-architecture-for-resiliency>), and troubleshooting performance (<https://learn.microsoft.com/en-us/troubleshoot/azure/expressroute/expressroute-troubleshooting-network-performance>).
+
 ### Private ASN vs public ASN (enterprise reality)
 
 This tends to confuse people because “ASN” sounds like an ISP thing.

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -146,67 +146,35 @@ This exact idea shows up again in cloud connectivity designs when you’re decid
 
 ## 4) Peering relationships in enterprise cloud connectivity
 
-If you strip away the product names, enterprise cloud connectivity is mostly just this:
+If you strip away the product names, enterprise cloud connectivity is mostly just this: you have internal prefixes on one side (data centres, campus, and branch sites), you have cloud prefixes on the other (VNets or VPCs, and whatever services sit behind them), and you use BGP to exchange routes between the two over some private transport.
 
-- you have some internal prefixes on one side (data centres, campus, branch sites)
-- you have some cloud prefixes on the other side (VNets/VPCs and their attached services)
-- and you use BGP to exchange routes between them over a private transport
-
-The transport could be:
-- MPLS / SD-WAN underlay
-- ExpressRoute / Direct Connect
-- a cloud exchange in a CNF (where you’ve got your own routers and L2 handoff to the peers)
+That transport could be an MPLS or SD-WAN underlay, ExpressRoute or Direct Connect, or a cloud exchange in a CNF (where you have your own routers, and an L2 handoff to the peers).
 
 ### What’s actually peering with what?
 
-In the model we’re using for this post:
+In the model we’re using for this post, your routers sit in one (or two) CNFs, you have L2 to each provider peer, and you run eBGP to Azure (ExpressRoute private peering), AWS (Direct Connect private VIF), and optionally your WAN provider(s) if you’re also aggregating MPLS or SD-WAN there.
 
-- Your routers sit in one (or two) CNFs.
-- You have L2 to each provider peer.
-- You run **eBGP** to:
-  - Azure (ExpressRoute private peering)
-  - AWS (Direct Connect private VIF)
-  - optionally your WAN provider(s) if you’re also aggregating MPLS/SD-WAN there.
-
-On the enterprise side, you then need to decide how those routes get back into the rest of your network:
-- iBGP to a core pair / route reflectors, or
-- redistribution into an IGP (with all the caveats that implies).
+On the enterprise side, you then need to decide how those routes get back into the rest of your network. That usually means iBGP to a core pair or route reflectors, or redistribution into an IGP (with all the caveats that implies).
 
 ### Private ASN vs public ASN (enterprise reality)
 
 This tends to confuse people because “ASN” sounds like an ISP thing.
 
-- **Private ASNs** are extremely common in enterprise designs.
-  - They’re fine as long as you understand where they are allowed to appear.
-- **Public ASNs** are usually only needed when you need to present a stable identity across the wider internet routing domain.
-  - Most enterprises don’t need that for private connectivity to cloud.
+Private ASNs are extremely common in enterprise designs, and they’re fine as long as you understand where they are allowed to appear. Public ASNs are usually only needed when you need to present a stable identity across the wider internet routing domain, which most enterprises do not need for private connectivity to cloud.
 
-The pragmatic rule: use a private ASN unless you have a reason not to.
+The pragmatic rule is simple: use a private ASN unless you have a reason not to.
 
 ### One ASN everywhere vs multiple ASNs
 
 This is where your MPLS experience is directly relevant.
 
-- **One ASN everywhere** (single enterprise ASN) can be clean.
-  - It pairs naturally with iBGP inside your network.
-  - But you need to design around loop prevention when routes traverse boundaries.
-
-- **Multiple ASNs** (per site / per edge) can be operationally convenient.
-  - It makes eBGP loop-prevention “just work” because each edge is a distinct AS.
-  - It does, however, complicate how far certain attributes can help you (we’ll come back to this in the CNF section).
+A single enterprise ASN everywhere can be clean because it pairs naturally with iBGP inside your network, but you need to design around loop prevention when routes traverse boundaries. Multiple ASNs (per site, or per edge) can be operationally convenient because it makes eBGP loop prevention “just work” at the cost of complicating how far certain attributes can help you, which we’ll come back to in the CNF section.
 
 ### A note on “influence vs control”
 
-Anything that crosses an AS boundary is, by definition, a negotiation.
+Anything that crosses an AS boundary is, by definition, a negotiation. You can usually control your own side completely, you can often influence your peer, but you rarely control what happens beyond your peer.
 
-You can usually control your own side completely.
-You can often influence your peer.
-But you rarely control what happens **beyond** your peer.
-
-That’s why a lot of BGP guidance boils down to:
-- keep your intent simple,
-- apply safety rails,
-- and don’t rely on a single knob (especially for inbound) unless you’ve validated the provider behaviour.
+That’s why a lot of BGP guidance boils down to keeping your intent simple, applying safety rails, and not relying on a single knob (especially for inbound) unless you’ve validated the provider behaviour.
 
 ## 5) Route advertisement basics (what you advertise and why)
 
@@ -215,16 +183,11 @@ Not because someone misunderstood the BGP decision process, but because someone 
 
 ### “Less is more”
 
-At an enterprise edge, you almost always want to:
-- advertise **only the prefixes you genuinely own and intend to be reachable**, and
-- accept **only the prefixes you actually need**.
+At an enterprise edge, you almost always want to advertise only the prefixes you genuinely own and intend to be reachable, and to accept only the prefixes you actually need.
 
 Everything else is just future-you doing incident response.
 
-Practically that means:
-- explicit prefix-lists for what you originate
-- route-policy that rejects “surprises” by default
-- max-prefix limits (we’ll cover these in the safety rails section)
+Practically, that means explicit prefix-lists for what you originate, route policy that rejects surprises by default, and max-prefix limits (we’ll cover those in the safety rails section).
 
 ### Private routes vs public routes (both exist in the cloud world)
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -276,9 +276,9 @@ On the enterprise side, you then need to decide how those routes get back into t
 :::warning ExpressRoute BGP essentials
 Microsoft Learn content about ExpressRoute often talks about “peerings” and “routing domains” without emphasising the mechanism. ExpressRoute is, in practice, delivered via redundant eBGP sessions.
 
-Each peering (Private peering, and Microsoft peering) is delivered via a pair of independent eBGP sessions. If you exceed prefix limits, the default behaviour is for the BGP session to be terminated, which is a hard failure mode and a good reason to monitor prefix counts.
+Each peering (Private peering, and Microsoft peering) is delivered via a pair of independent eBGP sessions. If you exceed prefix limits, the BGP session is terminated by default — a hard failure mode and a good reason to monitor prefix counts. Default limits are 4,000 prefixes for private peering (10,000 with ExpressRoute Premium) and 200 for Microsoft peering; sessions restore automatically once the prefix count drops back below the limit.
 
-Microsoft-side BGP timers are fixed (keepalive and hold), so fast failover is normally achieved with BFD, which is enabled by default on Microsoft’s side, but must be configured on your CPE.
+Microsoft-side BGP timers are fixed at 60 seconds keepalive and 180 seconds hold and can’t be changed on Microsoft’s side. You can configure lower timers on your CPE and the session will negotiate to the lower value, though Microsoft recommends BFD instead for fast failover. BFD is enabled by default on Microsoft’s side for new peerings, but needs to be configured on your CPE to be effective.
 
 > **BFD** (Bidirectional Forwarding Detection): a fast failure-detection mechanism often used to speed up BGP convergence.
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -471,13 +471,6 @@ A few practical notes: in real configs you’ll almost always include explicit r
 
 This post includes Mermaid diagrams for the key architectural patterns. If I’ve missed an example you care about, it’s usually a sign I should diagram it out.
 
-## TODO (new topics to incorporate)
-
-- Add a short section or sidebar on **BGP inside AWS constructs**, for example Amazon **VPC Route Server** driving VPC route table and IGW route table changes for dynamic routing patterns (floating IP failover, and firewall insertion).
-- Add a short section on **AWS Cloud WAN Connect** in an enterprise WAN framing, including the MP-BGP/IPv6 nuance, ECMP, and the “GRE versus tunnel-less” design choice.
-- Add an operational section or sidebar on **proving resiliency**, including AWS **Direct Connect failover testing** and the idea of regular game-days.
-- Add an optional routing security sidebar: AWS’s posture on **RPKI/ROV** as context, and what that implies for enterprise expectations and internal hygiene.
-
 ## Influencing inbound traffic (enterprise reality)
 
 Inbound is where BGP stops feeling like “routing” and starts feeling like diplomacy.
@@ -893,6 +886,26 @@ Some practical differences you’ll feel are that you’re peering to a cloud se
 Public peering options exist too, and they come with sharp edges. DX public VIF and ER Microsoft peering can be great for predictable paths to public services, but they’re also where you really don’t want to accidentally export something that turns you into transit.
 
 Finally, availability patterns are “product-shaped”. You’ll often have multiple BGP sessions per circuit, dual circuits, and region and site diversity patterns. The BGP knobs are the same, but the constraints around them are not.
+
+> Sidebar: BGP inside AWS constructs (it’s not just a hybrid edge protocol)
+>
+> BGP is no longer only about Direct Connect at the edge. AWS now has constructs where BGP drives changes inside the VPC routing domain.
+>
+> A good example is Amazon VPC Route Server, which can use BGP to influence route tables (including IGW route tables) for patterns like floating IP failover, or steering traffic through active/standby inspection appliances.
+>
+> Useful starting point: <https://aws.amazon.com/blogs/networking-and-content-delivery/dynamic-routing-using-amazon-vpc-route-server/>
+
+> Sidebar: AWS Cloud WAN Connect and MP-BGP reality
+>
+> If you’re integrating SD-WAN or building a global enterprise WAN overlay, AWS Cloud WAN Connect is another place BGP shows up. It’s also a good reminder that modern enterprise designs often exchange IPv6 routes over MP-BGP, even when the BGP adjacency itself is IPv4.
+>
+> Reference: <https://aws.amazon.com/blogs/networking-and-content-delivery/building-resilient-ipv6-network-with-sd-wans-and-aws-cloud-wan-connect-with-gre/>
+
+> Sidebar: prove your resiliency, don’t just design it
+>
+> BGP failover only matters if you’ve tested it. AWS provides guidance and tooling for deliberately failing over Direct Connect virtual interfaces, which makes it easier to run proper game-days.
+>
+> Reference: <https://aws.amazon.com/blogs/networking-and-content-delivery/testing-aws-direct-connect-resiliency-with-resiliency-toolkit-failover-testing/>
 
 ### Route Server (brief pointer)
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -29,12 +29,12 @@ BGP is a _path-vector_ routing protocol. You don’t “discover the best path�
 
 BGP is also **policy-first**. It’s designed for environments where “best” isn’t purely a function of link cost; it’s driven by _business relationships_, _operational preferences_, and _intent_.
 
-> Sidebar: “BGP isn’t an IGP”… except when it is.
->
-> In most enterprise networks, BGP isn’t used as an IGP. But at very large scale (I’ve seen this first-hand at Walmart), some organisations do run BGP internally because the scaling and operational trade-offs can work out better than running a giant link-state domain.
->
-> If you want the deeper reasoning: I wrote about OSPF scaling constraints and why BGP scales differently here:
-> https://www.simonpainter.com/dijkstra-ospf/
+:::note “BGP isn’t an IGP”… except when it is.
+In most enterprise networks, BGP isn’t used as an IGP. But at very large scale (I’ve seen this first-hand at Walmart), some organisations do run BGP internally because the scaling and operational trade-offs can work out better than running a giant link-state domain.
+
+If you want the deeper reasoning: I wrote about OSPF scaling constraints and why BGP scales differently here:
+https://www.simonpainter.com/dijkstra-ospf/
+:::
 
 ## eBGP and iBGP at the cloud edge
 
@@ -66,37 +66,37 @@ Typical triggers are two edge routers in the same site (active/active), two CNFs
 
 You _can_ avoid iBGP by doing weird things (like re-advertising routes between eBGP peers and hoping loop prevention doesn’t bite you), but iBGP is usually the right tool.
 
-> Note: this is where people start hearing about route reflectors.
->
-> You don’t need them in a small design, but once you have “lots of BGP speakers”, full-mesh iBGP becomes annoying because iBGP requires every router to peer with every other router (or you introduce route reflection/confederations).
+:::note this is where people start hearing about route reflectors.
+You don’t need them in a small design, but once you have “lots of BGP speakers”, full-mesh iBGP becomes annoying because iBGP requires every router to peer with every other router (or you introduce route reflection/confederations).
+:::
 
 ### Why you care
 
 Because **your operational knobs behave differently depending on where you are**. LOCAL_PREF is your best “pick the outbound exit” tool, but it’s only meaningful inside your AS. MED is, at best, a hint to a neighbour, and it is typically only compared in narrow conditions. AS_PATH prepending is crude, but it’s one of the few signals that naturally propagates beyond your first-hop peer.
 
-> Sidebar: iBGP, eBGP, and where they sit in the route selection hierarchy
->
-> There are two different “selection” processes people conflate.
->
-> One is the BGP best-path algorithm, which chooses one BGP path over another.
->
-> The other is the router’s global route selection behaviour, where different protocols all claim they can reach the same destination prefix, and the router has to choose which one makes it into the forwarding table.
->
-> On Cisco platforms, the default administrative distances reflect a common design assumption: BGP speakers are at the edge. eBGP-learned routes are therefore treated as a strong signal for external reachability, while iBGP-learned routes are treated as much less preferable than IGP-learned routes.
->
-> The rationale is pragmatic. If you’ve already learned the route from the IGP, it’s often “closer” and more efficient to follow that IGP path than to follow an iBGP hop-count that might simply be reflecting policy, or topology you don’t want to traverse.
->
-> The punchline is that if you redistribute between protocols, or if you run BGP deep in the network, you should understand how administrative distance interacts with BGP, and consider whether you need to tune it for your design.
->
-> Sidebar: iBGP and eBGP multipath (and why you suddenly care in cloud)
->
-> BGP is often taught as “pick one best path”, which is true for what it advertises, but not always true for what it forwards.
->
-> Most platforms can install multiple equal-cost BGP paths for the same prefix (multipath) and then forward over them using ECMP. Whether paths are considered “equal enough” depends on the platform and config, but the important point is that multipath is an explicit design choice.
->
-> This matters in cloud connectivity because active/active circuit pairs often rely on it. ExpressRoute in particular is commonly delivered as redundant circuit pairs, and many designs expect to use both links in steady state. Without multipath, you can easily end up with “one link hot, one link cold”, even though you paid for both.
->
-> If you need symmetric flows through stateful appliances, you might still choose active/passive, but if you are aiming for active/active, make sure you understand how your platform handles eBGP multipath, iBGP multipath, and the tie-breaks that decide which paths qualify.
+:::note iBGP, eBGP, and where they sit in the route selection hierarchy
+There are two different “selection” processes people conflate.
+
+One is the BGP best-path algorithm, which chooses one BGP path over another.
+
+The other is the router’s global route selection behaviour, where different protocols all claim they can reach the same destination prefix, and the router has to choose which one makes it into the forwarding table.
+
+On Cisco platforms, the default administrative distances reflect a common design assumption: BGP speakers are at the edge. eBGP-learned routes are therefore treated as a strong signal for external reachability, while iBGP-learned routes are treated as much less preferable than IGP-learned routes.
+
+The rationale is pragmatic. If you’ve already learned the route from the IGP, it’s often “closer” and more efficient to follow that IGP path than to follow an iBGP hop-count that might simply be reflecting policy, or topology you don’t want to traverse.
+
+The punchline is that if you redistribute between protocols, or if you run BGP deep in the network, you should understand how administrative distance interacts with BGP, and consider whether you need to tune it for your design.
+
+Sidebar: iBGP and eBGP multipath (and why you suddenly care in cloud)
+
+BGP is often taught as “pick one best path”, which is true for what it advertises, but not always true for what it forwards.
+
+Most platforms can install multiple equal-cost BGP paths for the same prefix (multipath) and then forward over them using ECMP. Whether paths are considered “equal enough” depends on the platform and config, but the important point is that multipath is an explicit design choice.
+
+This matters in cloud connectivity because active/active circuit pairs often rely on it. ExpressRoute in particular is commonly delivered as redundant circuit pairs, and many designs expect to use both links in steady state. Without multipath, you can easily end up with “one link hot, one link cold”, even though you paid for both.
+
+If you need symmetric flows through stateful appliances, you might still choose active/passive, but if you are aiming for active/active, make sure you understand how your platform handles eBGP multipath, iBGP multipath, and the tie-breaks that decide which paths qualify.
+:::
 
 If you understand the eBGP/iBGP boundary, the rest of BGP becomes much less mysterious.
 
@@ -268,17 +268,17 @@ flowchart LR
 
 On the enterprise side, you then need to decide how those routes get back into the rest of your network. That usually means iBGP to a core pair or route reflectors, or redistribution into an IGP (with all the caveats that implies).
 
-> ExpressRoute BGP essentials
->
-> Microsoft Learn content about ExpressRoute often talks about “peerings” and “routing domains” without emphasising the mechanism. ExpressRoute is, in practice, delivered via redundant eBGP sessions.
->
-> Each peering (Private peering, and Microsoft peering) is delivered via a pair of independent eBGP sessions. If you exceed prefix limits, the default behaviour is for the BGP session to be terminated, which is a hard failure mode and a good reason to monitor prefix counts.
->
-> Microsoft-side BGP timers are fixed (keepalive and hold), so fast failover is normally achieved with BFD, which is enabled by default on Microsoft’s side, but must be configured on your CPE.
->
-> Filtering is primarily your responsibility on the on-prem edge. Azure UDRs are static and not part of BGP advertisement. On Microsoft peering specifically, “no routes” is often explained by a missing route filter.
->
-> References: circuit peerings and BGP behaviour (<https://learn.microsoft.com/en-us/azure/expressroute/expressroute-circuit-peerings>), ExpressRoute FAQs (<https://learn.microsoft.com/en-us/azure/expressroute/expressroute-faqs>), resiliency guidance (<https://learn.microsoft.com/en-us/azure/expressroute/design-architecture-for-resiliency>), and troubleshooting performance (<https://learn.microsoft.com/en-us/troubleshoot/azure/expressroute/expressroute-troubleshooting-network-performance>).
+:::warning ExpressRoute BGP essentials
+Microsoft Learn content about ExpressRoute often talks about “peerings” and “routing domains” without emphasising the mechanism. ExpressRoute is, in practice, delivered via redundant eBGP sessions.
+
+Each peering (Private peering, and Microsoft peering) is delivered via a pair of independent eBGP sessions. If you exceed prefix limits, the default behaviour is for the BGP session to be terminated, which is a hard failure mode and a good reason to monitor prefix counts.
+
+Microsoft-side BGP timers are fixed (keepalive and hold), so fast failover is normally achieved with BFD, which is enabled by default on Microsoft’s side, but must be configured on your CPE.
+
+Filtering is primarily your responsibility on the on-prem edge. Azure UDRs are static and not part of BGP advertisement. On Microsoft peering specifically, “no routes” is often explained by a missing route filter.
+
+References: circuit peerings and BGP behaviour (<https://learn.microsoft.com/en-us/azure/expressroute/expressroute-circuit-peerings>), ExpressRoute FAQs (<https://learn.microsoft.com/en-us/azure/expressroute/expressroute-faqs>), resiliency guidance (<https://learn.microsoft.com/en-us/azure/expressroute/design-architecture-for-resiliency>), and troubleshooting performance (<https://learn.microsoft.com/en-us/troubleshoot/azure/expressroute/expressroute-troubleshooting-network-performance>).
+:::
 
 ### Private ASN vs public ASN (enterprise reality)
 
@@ -321,10 +321,10 @@ But both Azure and AWS also have public peering-style options where you can exch
 
 Why you’d do it is straightforward: you get predictable latency and jitter versus the internet, you avoid hairpinning through generic internet egress, and you can improve the path to cloud SaaS and public endpoints where it matters.
 
-> Sidebar: public peering doesn’t magically make the services private.
->
-> You’re still reaching public IPs. You’re just reaching them over a different transport.
-> The security model (identity, TLS, authz) still matters.
+:::note public peering doesn’t magically make the services private.
+You’re still reaching public IPs. You’re just reaching them over a different transport.
+The security model (identity, TLS, authz) still matters.
+:::
 
 ### Summarisation (and the sharp edges)
 
@@ -355,19 +355,19 @@ When a router has multiple routes to the same destination prefix, it picks a “
 
 In practice, for enterprise connectivity, you can think in three buckets: things you set internally to steer your outbound (for example, LOCAL_PREF), things you can signal to a neighbour to influence inbound (for example, MED and AS_PATH), and tie-breakers, where BGP picks something stable when your policy doesn’t decide.
 
-> Sidebar: the BGP path selection algorithm (and where it actually applies)
->
-> It’s easy to read a “BGP best path” list and assume BGP is making a global routing decision across your whole table. It isn’t.
->
-> The important nuance is that the BGP path selection algorithm only runs when you have multiple candidate paths for the same prefix, and it’s effectively comparing like-for-like. Longest Prefix Match (LPM) happens first, which means the “BGP decision process” is, in practice, mostly about choosing between routes of the same prefix length.
->
-> That’s one of the reasons providers often enforce a minimum, maximum, or fixed acceptable prefix length in their routing policy. They’re trying to keep the routing domain sane, and they’re also trying to avoid customers using more-specific prefixes as a cheap trick to bypass policy and traffic engineering.
->
-> If you want the rationale for why prefix length wins before any BGP attribute, and why we shouldn’t abuse it, this post is the best explanation I’ve written: https://www.simonpainter.com/longest-prefix-matching/
->
-> Vendor note: the exact tie-break order differs slightly between implementations, and there are knobs to change it. Junos has a good write-up here, including its default MED comparison behaviour and the options that alter it: https://www.juniper.net/documentation/us/en/software/junos/vpn-l2/bgp/topics/concept/routing-protocols-address-representation.html
->
-> Cisco has a canonical write-up too (and it’s a good reminder that Cisco has router-local attributes like WEIGHT that don’t exist everywhere): https://www.cisco.com/c/en/us/support/docs/ip/border-gateway-protocol-bgp/13753-25.html
+:::note the BGP path selection algorithm (and where it actually applies)
+It’s easy to read a “BGP best path” list and assume BGP is making a global routing decision across your whole table. It isn’t.
+
+The important nuance is that the BGP path selection algorithm only runs when you have multiple candidate paths for the same prefix, and it’s effectively comparing like-for-like. Longest Prefix Match (LPM) happens first, which means the “BGP decision process” is, in practice, mostly about choosing between routes of the same prefix length.
+
+That’s one of the reasons providers often enforce a minimum, maximum, or fixed acceptable prefix length in their routing policy. They’re trying to keep the routing domain sane, and they’re also trying to avoid customers using more-specific prefixes as a cheap trick to bypass policy and traffic engineering.
+
+If you want the rationale for why prefix length wins before any BGP attribute, and why we shouldn’t abuse it, this post is the best explanation I’ve written: https://www.simonpainter.com/longest-prefix-matching/
+
+Vendor note: the exact tie-break order differs slightly between implementations, and there are knobs to change it. Junos has a good write-up here, including its default MED comparison behaviour and the options that alter it: https://www.juniper.net/documentation/us/en/software/junos/vpn-l2/bgp/topics/concept/routing-protocols-address-representation.html
+
+Cisco has a canonical write-up too (and it’s a good reminder that Cisco has router-local attributes like WEIGHT that don’t exist everywhere): https://www.cisco.com/c/en/us/support/docs/ip/border-gateway-protocol-bgp/13753-25.html
+:::
 
 ### The three attributes you’ll use constantly
 
@@ -407,11 +407,11 @@ Higher LOCAL_PREF wins.
 
 It’s popular for three reasons: it’s deterministic, it’s simple to reason about, and it doesn’t require you to play games with AS_PATH length.
 
-> Sidebar: ECMP vs active/passive is often dictated by security appliances.
->
-> ECMP (active/active) has real value, but plenty of real networks have stateful firewalls or NAT devices that **aren’t clustered**.
-> Those designs often require **symmetric paths** (same in and out) to avoid breaking sessions.
-> In that world, active/passive circuits aren’t a failure of imagination; they’re a pragmatic requirement.
+:::note ECMP vs active/passive is often dictated by security appliances.
+ECMP (active/active) has real value, but plenty of real networks have stateful firewalls or NAT devices that **aren’t clustered**.
+Those designs often require **symmetric paths** (same in and out) to avoid breaking sessions.
+In that world, active/passive circuits aren’t a failure of imagination; they’re a pragmatic requirement.
+:::
 
 ### Pattern: prefer exit A, keep exit B as backup
 
@@ -561,10 +561,10 @@ A pragmatic ordering is:
 2. If you’re dual-connected to the _same_ provider AS and they honour MED: MED can work cleanly.
 3. If you need a portable signal that propagates: prepend on the less-preferred circuit.
 
-> Sidebar: there is no guarantee of perfect symmetry.
->
-> Even when you do everything “right”, you can end up with a symmetric _intent_ but asymmetric _reality_.
-> Failures, maintenance, hot-potato routing and upstream policy all get a vote.
+:::note there is no guarantee of perfect symmetry.
+Even when you do everything “right”, you can end up with a symmetric _intent_ but asymmetric _reality_.
+Failures, maintenance, hot-potato routing and upstream policy all get a vote.
+:::
 
 ### Communities (conceptual)
 
@@ -739,11 +739,11 @@ The fix is boring and effective: strict import filters (what you accept), and st
 
 Import filtering is more than just prefix-lists. In real designs you will often also filter based on AS_PATH and communities. You might explicitly exclude routes with certain ASNs in the path, you might import only routes sourced from a specific ASN (to avoid your peer becoming an accidental transit), and you might use communities as the selection key, for example AWS regional indicators.
 
-> Sidebar: regional route filtering to keep control of latency
->
-> At a large fintech I worked at we had ExpressRoute and Direct Connect in many regions. We deliberately imported only the cloud routes that were relevant to each region, because we wanted inter-region traffic to stay on our own low-latency network, not to wander across a hyperscaler backbone just because it was reachable.
->
-> This is where communities become genuinely useful, not for “clever traffic engineering”, but as a clean mechanism to scope what you import.
+:::note regional route filtering to keep control of latency
+At a large fintech I worked at we had ExpressRoute and Direct Connect in many regions. We deliberately imported only the cloud routes that were relevant to each region, because we wanted inter-region traffic to stay on our own low-latency network, not to wander across a hyperscaler backbone just because it was reachable.
+
+This is where communities become genuinely useful, not for “clever traffic engineering”, but as a clean mechanism to scope what you import.
+:::
 
 ### Example: dual-provider internet peering (don’t become transit)
 
@@ -838,28 +838,28 @@ On the other hand, in some **private multi-cloud CNF** designs, you might _delib
 - e.g., allow private traffic from Cloud A to reach Cloud B via your exchange routers.
 - That’s a valid architecture, but only if you do it intentionally, and keep it isolated from public-routing domains.
 
-> Sidebar: RPSL (Routing Policy Specification Language)
->
-> In the public internet, routing policy is often described using RPSL objects (route/route6, aut-num, etc.), which are then used to build prefix filters.
-> It’s one of the reasons “who should accept what from whom” can be automated at scale.
->
-> If you’ve never bumped into it before: https://en.wikipedia.org/wiki/Routing_Policy_Specification_Language
->
-> Sidebar: a quick note on RPKI and route validation
->
-> RPKI is the mechanism that lets prefix holders publish cryptographic Route Origin Authorisations (ROAs), and lets networks validate whether a route announcement is likely to be legitimate.
->
-> Even if your enterprise BGP is mostly “private”, the upstreams you depend on operate in the public routing system, and the industry is increasingly treating RPKI-invalid routes as something to drop, not just something to log.
->
-> AWS has a good high-level write-up of what they’re doing here, which is useful context: https://aws.amazon.com/blogs/networking-and-content-delivery/how-aws-is-helping-to-secure-internet-routing/
+:::note RPSL (Routing Policy Specification Language)
+In the public internet, routing policy is often described using RPSL objects (route/route6, aut-num, etc.), which are then used to build prefix filters.
+It’s one of the reasons “who should accept what from whom” can be automated at scale.
 
-> Sidebar: how Azure prevents some transit scenarios
->
-> Microsoft actively prevents certain transit-routing behaviours in the backbone (for good reasons).
-> If you’re using Route Server + ExpressRoute in multi-hub designs, this can show up as “routes learned in one place aren’t propagated to another” when a shared circuit is involved.
->
-> I wrote up the behaviour and the design implications here:
-> https://www.simonpainter.com/transit-route-prevention/
+If you’ve never bumped into it before: https://en.wikipedia.org/wiki/Routing_Policy_Specification_Language
+
+Sidebar: a quick note on RPKI and route validation
+
+RPKI is the mechanism that lets prefix holders publish cryptographic Route Origin Authorisations (ROAs), and lets networks validate whether a route announcement is likely to be legitimate.
+
+Even if your enterprise BGP is mostly “private”, the upstreams you depend on operate in the public routing system, and the industry is increasingly treating RPKI-invalid routes as something to drop, not just something to log.
+
+AWS has a good high-level write-up of what they’re doing here, which is useful context: https://aws.amazon.com/blogs/networking-and-content-delivery/how-aws-is-helping-to-secure-internet-routing/
+:::
+
+:::note how Azure prevents some transit scenarios
+Microsoft actively prevents certain transit-routing behaviours in the backbone (for good reasons).
+If you’re using Route Server + ExpressRoute in multi-hub designs, this can show up as “routes learned in one place aren’t propagated to another” when a shared circuit is involved.
+
+I wrote up the behaviour and the design implications here:
+https://www.simonpainter.com/transit-route-prevention/
+:::
 
 ### Max-prefix
 
@@ -869,17 +869,17 @@ It limits how many routes you’re willing to accept from a neighbour. If you ex
 
 A pragmatic enterprise approach is to set max-prefix on every eBGP peer, to size the threshold based on what you _expect_ (plus headroom), and to decide the failure mode ahead of time, for example warn-only logging versus hard-teardown.
 
-> Sidebar: max-prefix as a rite of passage
->
-> BT have historically had a very low default prefix limit on some enterprise BGP peerings.
->
-> At ASDA, it was almost a rite of passage that someone would, at least once in their time there, remove or loosen a prefix filter, hit the prefix limit, and watch the BGP session drop.
->
-> The extra sting is that BT don’t necessarily auto-timeout and recover quickly. Even after you fix the policy, you may need to raise a priority support ticket to get the peering reset.
->
-> The lesson is simple, and painfully memorable. BT are protecting themselves aggressively from customers accidentally, or deliberately, advertising too many routes and filling up router memory.
->
-> A core principle of BGP is that it’s typically at your perimeter, so you should not trust the motives or capabilities of a peer. Always apply your own import policy, export policy, and limits to protect yourself.
+:::warning max-prefix as a rite of passage
+BT have historically had a very low default prefix limit on some enterprise BGP peerings.
+
+At ASDA, it was almost a rite of passage that someone would, at least once in their time there, remove or loosen a prefix filter, hit the prefix limit, and watch the BGP session drop.
+
+The extra sting is that BT don’t necessarily auto-timeout and recover quickly. Even after you fix the policy, you may need to raise a priority support ticket to get the peering reset.
+
+The lesson is simple, and painfully memorable. BT are protecting themselves aggressively from customers accidentally, or deliberately, advertising too many routes and filling up router memory.
+
+A core principle of BGP is that it’s typically at your perimeter, so you should not trust the motives or capabilities of a peer. Always apply your own import policy, export policy, and limits to protect yourself.
+:::
 
 If you’re peering with an upstream that can legitimately send you huge tables (e.g., full routes), max-prefix is still useful; you just size it appropriately.
 
@@ -906,25 +906,25 @@ Public peering options exist too, and they come with sharp edges. DX public VIF 
 
 Finally, availability patterns are “product-shaped”. You’ll often have multiple BGP sessions per circuit, dual circuits, and region and site diversity patterns. The BGP knobs are the same, but the constraints around them are not.
 
-> Sidebar: BGP inside AWS constructs (it’s not just a hybrid edge protocol)
->
-> BGP is no longer only about Direct Connect at the edge. AWS now has constructs where BGP drives changes inside the VPC routing domain.
->
-> A good example is Amazon VPC Route Server, which can use BGP to influence route tables (including IGW route tables) for patterns like floating IP failover, or steering traffic through active/standby inspection appliances.
->
-> Useful starting point: <https://aws.amazon.com/blogs/networking-and-content-delivery/dynamic-routing-using-amazon-vpc-route-server/>
+:::note BGP inside AWS constructs (it’s not just a hybrid edge protocol)
+BGP is no longer only about Direct Connect at the edge. AWS now has constructs where BGP drives changes inside the VPC routing domain.
 
-> Sidebar: AWS Cloud WAN Connect and MP-BGP reality
->
-> If you’re integrating SD-WAN or building a global enterprise WAN overlay, AWS Cloud WAN Connect is another place BGP shows up. It’s also a good reminder that modern enterprise designs often exchange IPv6 routes over MP-BGP, even when the BGP adjacency itself is IPv4.
->
-> Reference: <https://aws.amazon.com/blogs/networking-and-content-delivery/building-resilient-ipv6-network-with-sd-wans-and-aws-cloud-wan-connect-with-gre/>
+A good example is Amazon VPC Route Server, which can use BGP to influence route tables (including IGW route tables) for patterns like floating IP failover, or steering traffic through active/standby inspection appliances.
 
-> Sidebar: prove your resiliency, don’t just design it
->
-> BGP failover only matters if you’ve tested it. AWS provides guidance and tooling for deliberately failing over Direct Connect virtual interfaces, which makes it easier to run proper game-days.
->
-> Reference: <https://aws.amazon.com/blogs/networking-and-content-delivery/testing-aws-direct-connect-resiliency-with-resiliency-toolkit-failover-testing/>
+Useful starting point: <https://aws.amazon.com/blogs/networking-and-content-delivery/dynamic-routing-using-amazon-vpc-route-server/>
+:::
+
+:::note AWS Cloud WAN Connect and MP-BGP reality
+If you’re integrating SD-WAN or building a global enterprise WAN overlay, AWS Cloud WAN Connect is another place BGP shows up. It’s also a good reminder that modern enterprise designs often exchange IPv6 routes over MP-BGP, even when the BGP adjacency itself is IPv4.
+
+Reference: <https://aws.amazon.com/blogs/networking-and-content-delivery/building-resilient-ipv6-network-with-sd-wans-and-aws-cloud-wan-connect-with-gre/>
+:::
+
+:::note prove your resiliency, don’t just design it
+BGP failover only matters if you’ve tested it. AWS provides guidance and tooling for deliberately failing over Direct Connect virtual interfaces, which makes it easier to run proper game-days.
+
+Reference: <https://aws.amazon.com/blogs/networking-and-content-delivery/testing-aws-direct-connect-resiliency-with-resiliency-toolkit-failover-testing/>
+:::
 
 ### Route Server (brief pointer)
 
@@ -933,15 +933,15 @@ If you’re using managed route distribution services (like Azure Route Server),
 I’ve written up one of the key behaviours and its design implications here:
 https://www.simonpainter.com/transit-route-prevention/
 
-> Sidebar: AWS Route Server versus Azure Route Server
->
-> AWS Route Server and Azure Route Server sound like the same thing, but they aren’t.
->
-> Azure Route Server is closer to “BGP as a Service”, it peers using standard BGP and can support transitive routing patterns that feel familiar to enterprise network engineers.
->
-> AWS Route Server is a more specialised tool, it is primarily about orchestrating active/passive appliance failover by manipulating specific route tables, and it is deliberately non-transitive.
->
-> If you want the deeper comparison (and the philosophy behind the difference), I wrote it up here: https://www.simonpainter.com/aws-route-server/
+:::note AWS Route Server versus Azure Route Server
+AWS Route Server and Azure Route Server sound like the same thing, but they aren’t.
+
+Azure Route Server is closer to “BGP as a Service”, it peers using standard BGP and can support transitive routing patterns that feel familiar to enterprise network engineers.
+
+AWS Route Server is a more specialised tool, it is primarily about orchestrating active/passive appliance failover by manipulating specific route tables, and it is deliberately non-transitive.
+
+If you want the deeper comparison (and the philosophy behind the difference), I wrote it up here: https://www.simonpainter.com/aws-route-server/
+:::
 
 ## Wrapping up
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -11,7 +11,7 @@ date: 2026-03-15
 draft: true
 ---
 
-I used to joke that the cloud networking exams, AZ-700 for Azure, and AWS Advanced Networking, were mostly just *“BGP in a GUI”*.
+I used to joke that the cloud networking exams, AZ-700 for Azure, and AWS Advanced Networking, were mostly just _“BGP in a GUI”_.
 
 It’s not really true. Both exams cover a lot more than that: security, load balancers, DNS, design patterns… the works.
 
@@ -25,9 +25,9 @@ So this post is an explainer of the key BGP concepts that an enterprise network 
 
 ## What BGP is (in one page)
 
-BGP is a *path-vector* routing protocol. You don’t “discover the best path” by calculating the shortest path through a topology (like you do with link-state protocols). Instead, you **learn candidate paths** via advertisements, then you **select** between them using a predictable decision process.
+BGP is a _path-vector_ routing protocol. You don’t “discover the best path” by calculating the shortest path through a topology (like you do with link-state protocols). Instead, you **learn candidate paths** via advertisements, then you **select** between them using a predictable decision process.
 
-BGP is also **policy-first**. It’s designed for environments where “best” isn’t purely a function of link cost; it’s driven by *business relationships*, *operational preferences*, and *intent*.
+BGP is also **policy-first**. It’s designed for environments where “best” isn’t purely a function of link cost; it’s driven by _business relationships_, _operational preferences_, and _intent_.
 
 > Sidebar: “BGP isn’t an IGP”… except when it is.
 >
@@ -41,7 +41,7 @@ BGP is also **policy-first**. It’s designed for environments where “best” 
 There are two flavours of BGP in day-to-day designs:
 
 - **eBGP** (external BGP): between different autonomous systems.
-- **iBGP** (internal BGP): between routers *inside* the same autonomous system.
+- **iBGP** (internal BGP): between routers _inside_ the same autonomous system.
 
 If you’ve only ever "touched BGP" at an MPLS edge, you’ve almost certainly only seen **eBGP**.
 Cloud connectivity tends to drag iBGP into the conversation because you suddenly have **multiple edges** (two routers, two sites, two CNFs, two clouds) and you need consistent policy and predictable failover.
@@ -53,7 +53,7 @@ eBGP is what you run between your network and someone else’s.
 In enterprise cloud connectivity that usually means your router in a CNF peering with an **ExpressRoute** MSEE or **Direct Connect** router, your router peering with an ISP, or your router peering with a managed MPLS provider PE.
 
 The important enterprise mental model is: **eBGP is where the AS boundary is real**.
-Across that boundary you can exchange routes, and you can *influence* the other side, but you don’t get to enforce how they do their internal routing.
+Across that boundary you can exchange routes, and you can _influence_ the other side, but you don’t get to enforce how they do their internal routing.
 
 ### iBGP
 
@@ -64,7 +64,7 @@ As soon as you add redundancy, iBGP becomes the clean way to make your edge beha
 
 Typical triggers are two edge routers in the same site (active/active), two CNFs (diverse meet-me rooms), two provider circuits (separate peers), or two clouds (Azure and AWS).
 
-You *can* avoid iBGP by doing weird things (like re-advertising routes between eBGP peers and hoping loop prevention doesn’t bite you), but iBGP is usually the right tool.
+You _can_ avoid iBGP by doing weird things (like re-advertising routes between eBGP peers and hoping loop prevention doesn’t bite you), but iBGP is usually the right tool.
 
 > Note: this is where people start hearing about route reflectors.
 >
@@ -102,7 +102,7 @@ If you understand the eBGP/iBGP boundary, the rest of BGP becomes much less myst
 
 ## Where enterprise engineers have seen BGP before: MPLS WAN patterns
 
-For a lot of enterprise folks, “BGP experience” starts and ends with *an MPLS circuit*.
+For a lot of enterprise folks, “BGP experience” starts and ends with _an MPLS circuit_.
 That’s fine, but it can leave you with some slightly warped assumptions, because MPLS providers can make BGP look like anything from “a normal eBGP peer” to “a magic ethernet cable between sites”.
 
 ### Managed CEs (you might never have seen the BGP config)
@@ -113,7 +113,7 @@ Mechanically, BGP is still often involved somewhere, but it’s just **not your 
 
 ### Common MPLS patterns (abstract mechanics)
 
-There are a few common ways MPLS WAN providers present routing. The exact implementation varies (VRFs, MP-BGP in the core, route targets, etc.), but the *customer-visible* behaviours are pretty consistent.
+There are a few common ways MPLS WAN providers present routing. The exact implementation varies (VRFs, MP-BGP in the core, route targets, etc.), but the _customer-visible_ behaviours are pretty consistent.
 
 ### Pattern A: PE/CE eBGP (provider AS visible)
 
@@ -157,15 +157,17 @@ Why this matters for the cloud journey: this is the closest mental model to DX/E
 
 > This is **not the typical MPLS model**; most MPLS WANs are built as a many-to-many L3VPN where you peer to the provider, and the provider does the route distribution.
 >
-> That said, I *have* seen real-world deployments where the MPLS network is treated as **a transport underlay**, and the **customer edge routers form BGP adjacencies with each other**.
+> That said, I _have_ seen real-world deployments where the MPLS network is treated as **a transport underlay**, and the **customer edge routers form BGP adjacencies with each other**.
 >
 > What it looks like from the customer’s point of view:
-> - Site A CE has BGP neighbours that are *other customer CEs*.
+>
+> - Site A CE has BGP neighbours that are _other customer CEs_.
 > - The provider ASN may not appear in the AS_PATH (because the provider isn’t acting as a BGP hop in your control plane).
 >
 > What has to be true for it to work:
+>
 > - The provider must provide **IP reachability between CEs** (it’s effectively giving you a routed any-to-any service), and
-> - the provider is **not** doing your inter-site route exchange for you; *your BGP* is.
+> - the provider is **not** doing your inter-site route exchange for you; _your BGP_ is.
 >
 > This pattern is conceptually closer to “running your own WAN overlay” than to classic managed MPLS L3VPN routing.
 >
@@ -200,6 +202,7 @@ Why this matters for the cloud journey: this is the closest mental model to DX/E
 ### Per-site ASNs
 
 A very common enterprise pattern is:
+
 - each site has its own private ASN, or
 - sites are grouped into a small pool of private ASNs.
 
@@ -211,9 +214,9 @@ It’s equally valid to run **the same ASN at every site**.
 
 But you need to understand one hard rule:
 
-- If site A advertises a prefix to the WAN, and that route is later presented to site B *with the same ASN still in the AS_PATH*, then **site B will drop it**.
+- If site A advertises a prefix to the WAN, and that route is later presented to site B _with the same ASN still in the AS_PATH_, then **site B will drop it**.
 
-That’s not a bug; that’s BGP doing loop prevention: *“I won’t accept a route that already contains my ASN.”*
+That’s not a bug; that’s BGP doing loop prevention: _“I won’t accept a route that already contains my ASN.”_
 
 So if you run “single ASN everywhere” using a private ASN, the provider typically has to do **private-AS removal/stripping** between sites.
 
@@ -340,8 +343,9 @@ If you use defaults, treat them like any other route. Filter them explicitly, se
 ## BGP path selection (the bits you actually use)
 
 BGP path selection looks intimidating until you realise two things:
-1) most of the decision process only matters when you have multiple candidate routes to the *same* prefix, and
-2) in enterprise designs you tend to use a small handful of attributes deliberately.
+
+1. most of the decision process only matters when you have multiple candidate routes to the _same_ prefix, and
+2. in enterprise designs you tend to use a small handful of attributes deliberately.
 
 We’ll keep this vendor-neutral and focus on the knobs you’ll actually touch at a cloud/WAN edge.
 
@@ -375,15 +379,17 @@ We’ll go deeper on how to use each of these in Sections 7 and 8.
 
 These come up constantly in enterprise cloud/WAN designs:
 
-1) **Single ASN, multiple upstream ASNs, and you want to override path selection**
+1. **Single ASN, multiple upstream ASNs, and you want to override path selection**
+
    - e.g., your preferred route has a longer AS_PATH, but you still want to send traffic that way.
    - Typical solution: **LOCAL_PREF**.
 
-2) **Two links to the same provider and you want symmetric preference**
+2. **Two links to the same provider and you want symmetric preference**
+
    - Outbound: **LOCAL_PREF**.
    - Inbound: **MED** (when honoured) or **AS_PATH prepending** (blunt but portable).
 
-3) **Two private ASNs (two edges) peered to a single remote ASN, and you want end-to-end path control**
+3. **Two private ASNs (two edges) peered to a single remote ASN, and you want end-to-end path control**
    - The tricky bit: LOCAL_PREF and MED don’t travel “downstream”.
    - The portable lever: AS_PATH signals (and, where supported, community-based knobs).
 
@@ -391,8 +397,8 @@ We’ll work through these explicitly as we go.
 
 ## Influencing outbound traffic (enterprise reality)
 
-Outbound is the part you *actually* control.
-If you’re deciding which circuit you want to use to *leave your network*, BGP gives you a few options, but in enterprise designs **LOCAL_PREF** is the one you’ll use constantly.
+Outbound is the part you _actually_ control.
+If you’re deciding which circuit you want to use to _leave your network_, BGP gives you a few options, but in enterprise designs **LOCAL_PREF** is the one you’ll use constantly.
 
 ### LOCAL_PREF (the clean internal lever)
 
@@ -486,7 +492,7 @@ This post includes Mermaid diagrams for the key architectural patterns. If I’v
 Inbound is where BGP stops feeling like “routing” and starts feeling like diplomacy.
 
 Outbound is easy: you choose which exit you use.
-Inbound is harder because you’re asking someone else (your peer) to choose a path *towards you*.
+Inbound is harder because you’re asking someone else (your peer) to choose a path _towards you_.
 
 That’s why you’ll often see enterprise designs that are either active/passive (make the path obvious), or heavily provider-specific, because the cleanest inbound levers are often communities.
 
@@ -494,13 +500,13 @@ That’s why you’ll often see enterprise designs that are either active/passiv
 
 There are three reasons inbound traffic engineering is fundamentally more limited:
 
-1) **The decision happens somewhere else.**
+1. **The decision happens somewhere else.**
    Your router doesn’t pick the inbound path. The upstream network does.
 
-2) **BGP is policy-based.**
+2. **BGP is policy-based.**
    The upstream might prefer “their cheapest exit” or “their preferred region” over your hints.
 
-3) **Some attributes don’t travel.**
+3. **Some attributes don’t travel.**
    The two attributes people most want to use (LOCAL_PREF and MED) often don’t help beyond the first hop.
 
 So your inbound strategy usually falls into one of these buckets: use a provider-supported knob (communities), use a crude but portable signal (AS_PATH), or accept that “good enough” beats “perfect”.
@@ -509,7 +515,7 @@ So your inbound strategy usually falls into one of these buckets: use a provider
 
 MED (Multi-Exit Discriminator) is designed for a very specific situation:
 
-> “Dear neighbour AS, *if you have multiple ways to reach me*, here’s the one I’d like you to prefer.”
+> “Dear neighbour AS, _if you have multiple ways to reach me_, here’s the one I’d like you to prefer.”
 
 In enterprise connectivity, MED is attractive because it’s conceptually neat. You can tag routes advertised on circuit A with a lower MED (more preferred), and tag routes advertised on circuit B with a higher MED (less preferred).
 
@@ -550,20 +556,21 @@ flowchart LR
   %% Inbound: provider decides the path towards you.
   %% Tools: communities (cleanest), MED (if honoured), AS_PATH prepend (portable).
 ```
+
 A pragmatic ordering is:
 
-1) If you have a provider-supported inbound knob (often communities): use that.
-2) If you’re dual-connected to the *same* provider AS and they honour MED: MED can work cleanly.
-3) If you need a portable signal that propagates: prepend on the less-preferred circuit.
+1. If you have a provider-supported inbound knob (often communities): use that.
+2. If you’re dual-connected to the _same_ provider AS and they honour MED: MED can work cleanly.
+3. If you need a portable signal that propagates: prepend on the less-preferred circuit.
 
 > Sidebar: there is no guarantee of perfect symmetry.
 >
-> Even when you do everything “right”, you can end up with a symmetric *intent* but asymmetric *reality*.
+> Even when you do everything “right”, you can end up with a symmetric _intent_ but asymmetric _reality_.
 > Failures, maintenance, hot-potato routing and upstream policy all get a vote.
 
 ### Communities (conceptual)
 
-BGP communities are one of the most useful “provider-supported knobs”, but they’re still *influence*, not control.
+BGP communities are one of the most useful “provider-supported knobs”, but they’re still _influence_, not control.
 
 They’re often the cleanest way to do inbound steering because the provider can map a community to an explicit internal policy (for example, changing local preference on their side).
 
@@ -575,7 +582,7 @@ https://www.simonpainter.com/community-comparison/
 BGP communities are just tags.
 That sounds underwhelming, but it’s exactly why they’re powerful.
 
-A community is a value (traditionally a 32-bit `X:Y` format, and in modern networks often *large communities*) that a router can attach to a route.
+A community is a value (traditionally a 32-bit `X:Y` format, and in modern networks often _large communities_) that a router can attach to a route.
 The receiving network can then match on that tag and apply policy.
 
 In other words, you tag routes with intent, and your peer maps that tag to behaviour.
@@ -771,6 +778,7 @@ flowchart LR
 ```
 
 **IOS-XE (illustrative)**
+
 ```ios
 ip prefix-list MY-PREFIXES seq 10 permit 203.0.113.0/24
 !
@@ -788,6 +796,7 @@ router bgp 65001
 ```
 
 **JunOS (illustrative)**
+
 ```junos
 policy-options {
   prefix-list MY-PREFIXES {
@@ -822,10 +831,12 @@ protocols {
 ```
 
 The same principle applies to **public cloud public-peering** models:
-- **DX public VIF** and **ER Microsoft peering** are *not* a place you want to accidentally become transit.
+
+- **DX public VIF** and **ER Microsoft peering** are _not_ a place you want to accidentally become transit.
 - If you’re receiving public prefixes from the provider, be deliberate about what you export back.
 
-On the other hand, in some **private multi-cloud CNF** designs, you might *deliberately* act as a transit:
+On the other hand, in some **private multi-cloud CNF** designs, you might _deliberately_ act as a transit:
+
 - e.g., allow private traffic from Cloud A to reach Cloud B via your exchange routers.
 - That’s a valid architecture, but only if you do it intentionally, and keep it isolated from public-routing domains.
 
@@ -858,7 +869,7 @@ Max-prefix is your seatbelt.
 
 It limits how many routes you’re willing to accept from a neighbour. If you expected “a few hundred prefixes” and you suddenly receive “the full internet”, max-prefix can stop that mistake becoming a widespread outage.
 
-A pragmatic enterprise approach is to set max-prefix on every eBGP peer, to size the threshold based on what you *expect* (plus headroom), and to decide the failure mode ahead of time, for example warn-only logging versus hard-teardown.
+A pragmatic enterprise approach is to set max-prefix on every eBGP peer, to size the threshold based on what you _expect_ (plus headroom), and to decide the failure mode ahead of time, for example warn-only logging versus hard-teardown.
 
 > Sidebar: max-prefix as a rite of passage
 >

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -110,9 +110,9 @@ Why this matters for the cloud journey: this is the closest mental model to DX/E
 
 #### Pattern B: CE–CE peering over MPLS (customer edges peer with each other)
 
-You called this out explicitly, and yes — I’ve seen this in the wild too.
+This is **not the typical MPLS model** — most MPLS WANs are built as a many-to-many L3VPN where you peer to the provider and the provider does the route distribution.
 
-In this design, the provider network is treated as **a transport underlay**, and the **customer edge routers form BGP adjacencies with each other** (directly or via some kind of rendezvous).
+That said, I *have* seen real-world deployments where the MPLS network is treated as **a transport underlay**, and the **customer edge routers form BGP adjacencies with each other** (directly or via some kind of rendezvous).
 
 What it looks like from the customer’s point of view:
 - Site A CE has BGP neighbours that are *other customer CEs*.

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -344,9 +344,7 @@ Inbound is where BGP stops feeling like “routing” and starts feeling like di
 Outbound is easy: you choose which exit you use.
 Inbound is harder because you’re asking someone else (your peer) to choose a path *towards you*.
 
-That’s why you’ll often see enterprise designs that are:
-- **active/passive** (make the path obvious), or
-- heavily **provider-specific** (because the cleanest inbound levers are often communities).
+That’s why you’ll often see enterprise designs that are either active/passive (make the path obvious), or heavily provider-specific, because the cleanest inbound levers are often communities.
 
 ### Why inbound is harder
 
@@ -361,10 +359,7 @@ There are three reasons inbound traffic engineering is fundamentally more limite
 3) **Some attributes don’t travel.**
    The two attributes people most want to use (LOCAL_PREF and MED) often don’t help beyond the first hop.
 
-So your inbound strategy usually falls into one of these buckets:
-- use a provider-supported knob (communities)
-- use a crude but portable signal (AS_PATH)
-- accept that “good enough” beats “perfect”
+So your inbound strategy usually falls into one of these buckets: use a provider-supported knob (communities), use a crude but portable signal (AS_PATH), or accept that “good enough” beats “perfect”.
 
 ### MED (when it’s honoured, and why it doesn’t travel far)
 
@@ -372,20 +367,11 @@ MED (Multi-Exit Discriminator) is designed for a very specific situation:
 
 > “Dear neighbour AS, *if you have multiple ways to reach me*, here’s the one I’d like you to prefer.”
 
-In enterprise connectivity, MED is attractive because it’s conceptually neat:
-- you can tag routes advertised on circuit A with a lower MED (more preferred)
-- and tag routes advertised on circuit B with a higher MED (less preferred)
+In enterprise connectivity, MED is attractive because it’s conceptually neat. You can tag routes advertised on circuit A with a lower MED (more preferred), and tag routes advertised on circuit B with a higher MED (less preferred).
 
-But there are limitations you should assume unless you’ve validated the provider behaviour:
+But there are limitations you should assume unless you’ve validated the provider behaviour. MED is only meaningful to your direct neighbour, so it’s not a downstream steering mechanism. Many networks only compare MEDs when the candidate paths are learned from the same neighbouring AS, so if you’re multi-homed to different upstream ASNs, MED usually won’t help. The neighbour can also ignore MED completely, or override it with their own policy.
 
-- **MED is only meaningful to your direct neighbour.** It’s not a downstream steering mechanism.
-- Many networks only compare MEDs when the candidate paths are learned from **the same neighbouring AS**.
-  - If you’re multi-homed to different upstream ASNs, MED usually won’t help.
-- The neighbour can ignore MED completely, or override it with their own policy.
-
-So the safe enterprise posture is:
-- **use MED when you have two links to the same provider AS and you know they honour it**
-- don’t build a fragile design that depends on it without a test
+So the safe enterprise posture is simple: use MED when you have two links to the same provider AS, and you know they honour it, and don’t build a fragile design that depends on it without a test.
 
 ### AS_PATH prepending (crude, but it propagates)
 
@@ -395,20 +381,13 @@ AS_PATH prepending is the hammer people reach for because it has one key propert
 
 If you make one path “look longer” by adding extra copies of your ASN, that signal can influence decisions not just in your direct neighbour, but further upstream.
 
-That said, it’s still not magic:
-- some networks have local policy that dominates AS_PATH length
-- once LOCAL_PREF or a community-based preference is set in the upstream, AS_PATH length might not matter
+That said, it’s still not magic. Some networks have local policy that dominates AS_PATH length, and once LOCAL_PREF or a community-based preference is set in the upstream, AS_PATH length might not matter.
 
-A practical way to think about prepend:
-- it’s good for “prefer this circuit most of the time”, not “pin every prefix to a specific link forever”.
+A practical way to think about prepend is that it’s good for “prefer this circuit most of the time”, not “pin every prefix to a specific link forever”.
 
 ### Putting it together: two links to the same provider
 
-This is the classic enterprise ask:
-
-- Outbound: prefer circuit A, keep B as backup (LOCAL_PREF)
-- Inbound: encourage the provider to send traffic to you via circuit A
-
+This is the classic enterprise ask. Outbound is “prefer circuit A, keep B as backup” (LOCAL_PREF), and inbound is “encourage the provider to send traffic to you via circuit A”.
 A pragmatic ordering is:
 
 1) If you have a provider-supported inbound knob (often communities): use that.
@@ -437,9 +416,7 @@ That sounds underwhelming, but it’s exactly why they’re powerful.
 A community is a value (traditionally a 32-bit `X:Y` format, and in modern networks often *large communities*) that a router can attach to a route.
 The receiving network can then match on that tag and apply policy.
 
-In other words:
-- **you tag routes with intent**
-- **your peer maps that tag to behaviour**
+In other words, you tag routes with intent, and your peer maps that tag to behaviour.
 
 That’s why communities are often the cleanest inbound influence mechanism.
 You’re not trying to “beat” someone else’s decision process; you’re asking them to apply a documented policy.
@@ -449,25 +426,11 @@ You’re not trying to “beat” someone else’s decision process; you’re as
 Communities don’t override the fact that BGP crosses administrative boundaries.
 The peer still decides what they honour.
 
-Treat communities as:
-- a supported API into your provider’s policy, not
-- a guaranteed steering mechanism.
+Treat communities as a supported API into your provider’s policy, not a guaranteed steering mechanism.
 
 ### Common community categories you’ll encounter
 
-The exact values are provider-specific, but the *themes* repeat:
-
-- **Scope / propagation control**
-  - e.g., `NO_EXPORT` (RFC 1997) or “don’t advertise this beyond region X”.
-
-- **Preference / traffic engineering**
-  - “prefer this path more/less” (often implemented as a local preference change on the provider side).
-
-- **Blackholing** (in some designs)
-  - “discard traffic to this prefix at the edge” (useful for DDoS response when supported).
-
-- **Service / region classification**
-  - especially for public-cloud public prefixes (filter by service, region, sovereign cloud, etc.).
+The exact values are provider-specific, but the themes repeat. You’ll see communities used for scope and propagation control (for example, NO_EXPORT (RFC 1997), or “don’t advertise this beyond region X”), preference and traffic engineering (“prefer this path more or less”, often implemented as a local preference change on the provider side), blackholing in some designs (“discard traffic to this prefix at the edge”), and service or region classification, especially for public-cloud public prefixes.
 
 ### AWS vs Azure: don’t assume they work the same
 
@@ -479,36 +442,21 @@ https://www.simonpainter.com/community-comparison/
 
 ### Practical advice
 
-- Start with the provider’s documentation for the specific connection type (DX public/private VIF; ER private/Microsoft peering).
-- Implement communities in code/policy with the same discipline as firewall rules:
-  - version control,
-  - review,
-  - explicit intent,
-  - and testing.
-- Prefer communities over “clever” AS_PATH games when the provider supports the behaviour you need.
+Start with the provider’s documentation for the specific connection type (DX public or private VIF, and ER private or Microsoft peering). Implement communities in code and policy with the same discipline as firewall rules, including version control, review, explicit intent, and testing. Prefer communities over “clever” AS_PATH games when the provider supports the behaviour you need.
 
 ## 10) Cloud exchange / carrier neutral facility (CNF) patterns
 
-A cloud exchange is typically a **carrier neutral facility (CNF)** where you can aggregate:
-- cloud provider connectivity (ExpressRoute / Direct Connect)
-- WAN connectivity (MPLS / SD-WAN)
+A cloud exchange is typically a **carrier neutral facility (CNF)** where you can aggregate cloud provider connectivity (ExpressRoute and Direct Connect), and WAN connectivity (MPLS and SD-WAN).
 
 In practice, a CNF is where enterprise networking starts to look a little bit like “real internet engineering”… except you’re doing it inside a building with cross-connects.
 
-Assumption for the examples in this post:
-- you host **your own routers** in the exchange, and
-- the exchange provides **L2** to each cloud peer (so you run BGP directly with the cloud/provider routers).
+The assumption for the examples in this post is that you host your own routers in the exchange, and the exchange provides L2 to each cloud peer, so you run BGP directly with the cloud and provider routers.
 
 ### Two-CNF diversity (why it’s common)
 
-A common pattern is to use **two CNFs** for physical and geographic diversity:
-- separate meet-me rooms
-- separate fibre paths
-- separate power domains / blast radius
+A common pattern is to use two CNFs for physical and geographic diversity, for example separate meet-me rooms, separate fibre paths, and separate power domains and blast radius.
 
-You then decide whether the design is:
-- **active/active northbound** (both CNFs have cloud peers up), or
-- **active/passive** (one CNF is preferred, the other is failover)
+You then decide whether the design is active/active northbound (both CNFs have cloud peers up), or active/passive (one CNF is preferred, and the other is failover).
 
 As we mentioned earlier, active/passive is often dictated by the southbound architecture (stateful firewalls, NAT, or policy constraints that require symmetric flow).
 
@@ -518,62 +466,27 @@ There are two common ways enterprises structure ASNs at the edge.
 
 #### Option A: single ASN across both CNFs (one enterprise AS)
 
-This is the “clean BGP” model.
+This is the “clean BGP” model. Both CNF routers are in the same ASN, you run eBGP to each cloud or provider peer, and you run iBGP between your CNF routers (and usually to the rest of your core).
 
-- Both CNF routers are in the same ASN.
-- You run eBGP to each cloud/provider peer.
-- You run iBGP between your CNF routers (and usually to the rest of your core).
+It’s nice because LOCAL_PREF works exactly how you expect for choosing your outbound exit, you can express “prefer CNF A for outbound, keep CNF B as backup” without AS_PATH games, and it tends to be easier to build deterministic failover.
 
-Why it’s nice:
-- **LOCAL_PREF works exactly how you expect** for choosing your outbound exit.
-- You can express “prefer CNF A for outbound, keep CNF B as backup” without AS_PATH games.
-- It tends to be easier to build deterministic failover.
-
-The trade-off:
-- you’re now in “iBGP design land” (full mesh vs route reflection, etc.).
+The trade-off is that you’re now in iBGP design land (full mesh versus route reflection, and so on).
 
 #### Option B: dual private ASNs (one per CNF)
 
-This is an operationally popular model in enterprises because it feels like “two edges”.
+This is an operationally popular model in enterprises because it feels like “two edges”. CNF A might be ASN 65001, CNF B might be ASN 65002, each CNF peers to the cloud or provider ASN, and somewhere downstream you have to reconnect those worlds (often another BGP hop inside your enterprise).
 
-- CNF A is ASN 65001.
-- CNF B is ASN 65002.
-- Each CNF peers to the cloud/provider ASN.
-- Somewhere downstream you have to reconnect those worlds (often another BGP hop inside your enterprise).
+People do it because it keeps the edges conceptually independent, and eBGP loop prevention can simplify some designs.
 
-Why people do it:
-- it keeps the edges conceptually independent
-- eBGP loop prevention can simplify some designs
-
-But it comes with important limitations for end-to-end traffic engineering:
-
-- **LOCAL_PREF is not transitive.**
-  - It’s your internal preference inside one ASN.
-  - If CNF A and CNF B are different ASNs, LOCAL_PREF you set in one doesn’t automatically help the other.
-
-- **MED is not a downstream steering tool.**
-  - Even when honoured, it’s a hint to your neighbour and typically scoped to comparisons within the same neighbour AS.
-
-- **AS_PATH does propagate.**
-  - That’s why prepend often becomes the “portable lever” in dual-AS edge designs.
+But it comes with important limitations for end-to-end traffic engineering. LOCAL_PREF is not transitive, so it is your internal preference inside one ASN, and if CNF A and CNF B are different ASNs, LOCAL_PREF you set in one doesn’t automatically help the other. MED is not a downstream steering tool either, so even when honoured it is a hint to your neighbour, and typically scoped to comparisons within the same neighbour AS. AS_PATH does propagate, which is why prepend often becomes the portable lever in dual-AS edge designs.
 
 ### Putting it together: “two private ASNs to one remote ASN”
 
-This is the scenario you called out earlier:
+This is the scenario you called out earlier. You have two edge ASNs, one per CNF, both peer to a single remote ASN (provider or cloud), and you want downstream parts of your enterprise (and sometimes other connected networks) to follow the right end-to-end path.
 
-- you have two edge ASNs (one per CNF)
-- both peer to a single remote ASN (provider/cloud)
-- you want downstream parts of *your* enterprise (and sometimes other connected networks) to follow the right end-to-end path
+The key mental model is that if the decision is happening inside one of your ASNs, LOCAL_PREF is king. If the decision is happening outside your AS, AS_PATH and provider-supported communities are the tools that can travel.
 
-The key mental model:
-
-- if the decision is happening **inside one of your ASNs**, LOCAL_PREF is king.
-- if the decision is happening **outside your AS**, AS_PATH and provider-supported communities are the tools that can travel.
-
-This is also where it becomes crucial to separate:
-- “what do I want for outbound?” (easy)
-- “what do I want for inbound?” (hard)
-- “what is my failure mode?” (the thing that makes the design real)
+This is also where it becomes crucial to separate what you want for outbound (easy), what you want for inbound (hard), and what your failure mode is (the thing that makes the design real).
 
 ## 11) Safety rails (the section that saves outages)
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -23,7 +23,7 @@ So this post is an explainer of the key BGP concepts that an enterprise network 
 
 <!--truncate-->
 
-## 1) What BGP is (in one page)
+## What BGP is (in one page)
 
 BGP is a *path-vector* routing protocol. You don’t “discover the best path” by calculating the shortest path through a topology (like you do with link-state protocols). Instead, you **learn candidate paths** via advertisements, then you **select** between them using a predictable decision process.
 
@@ -36,7 +36,7 @@ BGP is also **policy-first**. It’s designed for environments where “best” 
 > If you want the deeper reasoning: I wrote about OSPF scaling constraints and why BGP scales differently here:
 > https://www.simonpainter.com/dijkstra-ospf/
 
-## 2) eBGP vs iBGP (what matters at the cloud edge)
+## eBGP vs iBGP (what matters at the cloud edge)
 
 There are two flavours of BGP in day-to-day designs:
 
@@ -90,7 +90,7 @@ Because **your operational knobs behave differently depending on where you are**
 
 If you understand the eBGP/iBGP boundary, the rest of BGP becomes much less mysterious.
 
-## 3) Where enterprise engineers have seen BGP before: MPLS WAN patterns
+## Where enterprise engineers have seen BGP before: MPLS WAN patterns
 
 For a lot of enterprise folks, “BGP experience” starts and ends with *an MPLS circuit*.
 That’s fine, but it can leave you with some slightly warped assumptions, because MPLS providers can make BGP look like anything from “a normal eBGP peer” to “a magic ethernet cable between sites”.
@@ -105,7 +105,7 @@ Mechanically, BGP is still often involved somewhere, but it’s just **not your 
 
 There are a few common ways MPLS WAN providers present routing. The exact implementation varies (VRFs, MP-BGP in the core, route targets, etc.), but the *customer-visible* behaviours are pretty consistent.
 
-#### Pattern A: PE/CE eBGP (provider AS visible)
+### Pattern A: PE/CE eBGP (provider AS visible)
 
 This is the “textbook” model. Your CE runs eBGP to the provider PE. The provider PE is in the provider’s ASN, so you see the provider AS in the AS_PATH (or at least you can). Your routes are imported into the provider’s MPLS VPN routing domain and distributed to other sites.
 
@@ -143,7 +143,7 @@ flowchart LR
 
 Why this matters for the cloud journey: this is the closest mental model to DX/ER peering.
 
-#### Pattern B (sidebar): CE–CE peering over MPLS (customer edges peer with each other)
+### Pattern B (sidebar): CE–CE peering over MPLS (customer edges peer with each other)
 
 > This is **not the typical MPLS model**; most MPLS WANs are built as a many-to-many L3VPN where you peer to the provider, and the provider does the route distribution.
 >
@@ -187,7 +187,7 @@ Why this matters for the cloud journey: this is the closest mental model to DX/E
 
 ### ASNs in MPLS enterprise designs
 
-#### Per-site ASNs
+### Per-site ASNs
 
 A very common enterprise pattern is:
 - each site has its own private ASN, or
@@ -195,7 +195,7 @@ A very common enterprise pattern is:
 
 It’s convenient because it keeps the eBGP loop-prevention behaviour simple: every site is “a different AS”, so re-advertisement between sites doesn’t trip over “I see myself in the AS_PATH”.
 
-#### Single ASN across all sites (and why private-AS stripping matters)
+### Single ASN across all sites (and why private-AS stripping matters)
 
 It’s equally valid to run **the same ASN at every site**.
 
@@ -209,7 +209,7 @@ So if you run “single ASN everywhere” using a private ASN, the provider typi
 
 This exact idea shows up again in cloud connectivity designs when you’re deciding whether to use one ASN globally, or split ASNs per edge/site.
 
-## 4) Peering relationships in enterprise cloud connectivity
+## Peering relationships in enterprise cloud connectivity
 
 If you strip away the product names, enterprise cloud connectivity is mostly just this: you have internal prefixes on one side (data centres, campus, and branch sites), you have cloud prefixes on the other (VNets or VPCs, and whatever services sit behind them), and you use BGP to exchange routes between the two over some private transport.
 
@@ -275,7 +275,7 @@ Anything that crosses an AS boundary is, by definition, a negotiation. You can u
 
 That’s why a lot of BGP guidance boils down to keeping your intent simple, applying safety rails, and not relying on a single knob (especially for inbound) unless you’ve validated the provider behaviour.
 
-## 5) Route advertisement basics (what you advertise and why)
+## Route advertisement basics (what you advertise and why)
 
 This is where most real-world BGP outages come from.
 Not because someone misunderstood the BGP decision process, but because someone advertised (or accepted) more routes than they intended.
@@ -315,7 +315,7 @@ Default routes are a great tool when used intentionally. In small branch designs
 
 If you use defaults, treat them like any other route. Filter them explicitly, set their preference intentionally, and test the failure mode (what happens when the preferred exit disappears?).
 
-## 6) BGP path selection (the bits you actually use)
+## BGP path selection (the bits you actually use)
 
 BGP path selection looks intimidating until you realise two things:
 1) most of the decision process only matters when you have multiple candidate routes to the *same* prefix, and
@@ -367,7 +367,7 @@ These come up constantly in enterprise cloud/WAN designs:
 
 We’ll work through these explicitly as we go.
 
-## 7) Influencing outbound traffic (enterprise reality)
+## Influencing outbound traffic (enterprise reality)
 
 Outbound is the part you *actually* control.
 If you’re deciding which circuit you want to use to *leave your network*, BGP gives you a few options, but in enterprise designs **LOCAL_PREF** is the one you’ll use constantly.
@@ -459,7 +459,7 @@ A few practical notes: in real configs you’ll almost always include explicit r
 
 This post includes Mermaid diagrams for the key architectural patterns. If I’ve missed an example you care about, it’s usually a sign I should diagram it out.
 
-## 8) Influencing inbound traffic (enterprise reality)
+## Influencing inbound traffic (enterprise reality)
 
 Inbound is where BGP stops feeling like “routing” and starts feeling like diplomacy.
 
@@ -548,7 +548,7 @@ They’re often the cleanest way to do inbound steering because the provider can
 I’ve written a more detailed comparison of how Azure and AWS use communities here:
 https://www.simonpainter.com/community-comparison/
 
-## 9) Communities (the provider-supported knobs)
+## Communities (the provider-supported knobs)
 
 BGP communities are just tags.
 That sounds underwhelming, but it’s exactly why they’re powerful.
@@ -584,7 +584,7 @@ https://www.simonpainter.com/community-comparison/
 
 Start with the provider’s documentation for the specific connection type (DX public or private VIF, and ER private or Microsoft peering). Implement communities in code and policy with the same discipline as firewall rules, including version control, review, explicit intent, and testing. Prefer communities over “clever” AS_PATH games when the provider supports the behaviour you need.
 
-## 10) Cloud exchange / carrier neutral facility (CNF) patterns
+## Cloud exchange / carrier neutral facility (CNF) patterns
 
 A cloud exchange is typically a **carrier neutral facility (CNF)** where you can aggregate cloud provider connectivity (ExpressRoute and Direct Connect), and WAN connectivity (MPLS and SD-WAN).
 
@@ -639,7 +639,7 @@ As we mentioned earlier, active/passive is often dictated by the southbound arch
 
 There are two common ways enterprises structure ASNs at the edge.
 
-#### Option A: single ASN across both CNFs (one enterprise AS)
+### Option A: single ASN across both CNFs (one enterprise AS)
 
 This is the “clean BGP” model. Both CNF routers are in the same ASN, you run eBGP to each cloud or provider peer, and you run iBGP between your CNF routers (and usually to the rest of your core).
 
@@ -647,7 +647,7 @@ It’s nice because LOCAL_PREF works exactly how you expect for choosing your ou
 
 The trade-off is that you’re now in iBGP design land (full mesh versus route reflection, and so on).
 
-#### Option B: dual private ASNs (one per CNF)
+### Option B: dual private ASNs (one per CNF)
 
 This is an operationally popular model in enterprises because it feels like “two edges”. CNF A might be ASN 65001, CNF B might be ASN 65002, each CNF peers to the cloud or provider ASN, and somewhere downstream you have to reconnect those worlds (often another BGP hop inside your enterprise).
 
@@ -696,7 +696,7 @@ flowchart LR
   %% AS_PATH and provider-supported communities are the tools that can travel beyond the edge.
 ```
 
-## 11) Safety rails (the section that saves outages)
+## Safety rails (the section that saves outages)
 
 ### Prefix-lists / route filtering
 
@@ -710,7 +710,7 @@ That’s rarely desirable, and it can also become expensive fast.
 
 The fix is boring and effective: strict import filters (what you accept), and strict export filters (what you advertise).
 
-#### Example: dual-provider internet peering (don’t become transit)
+### Example: dual-provider internet peering (don’t become transit)
 
 In this pattern you receive routes from two upstreams, but you only ever advertise your own prefixes, and optionally a default or a small set of aggregates you explicitly intend to originate.
 
@@ -847,7 +847,7 @@ The exact commands differ (IOS-XE versus JunOS), but the operational goal is the
 If your platform supports route refresh, use it.
 If it doesn’t, you’ll end up doing some kind of clear/reset; just do it intentionally, and during a safe window.
 
-## 12) Cloud specifics (light touch)
+## Cloud specifics (light touch)
 
 This post is intentionally vendor-neutral, but cloud connectivity has a few “cloud-shaped” differences that are worth keeping in mind.
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -191,20 +191,11 @@ Practically, that means explicit prefix-lists for what you originate, route poli
 
 ### Private routes vs public routes (both exist in the cloud world)
 
-Most people start with **private** connectivity:
-- you advertise RFC1918 (or your internal private space) towards the cloud,
-- you receive cloud private prefixes back,
-- and you use that for VNet/VPC reachability.
+Most people start with private connectivity. You advertise RFC1918 (or your internal private space) towards the cloud, you receive cloud private prefixes back, and you use that for VNet or VPC reachability.
 
-But both Azure and AWS also have **public peering-style** options where you can exchange **public routes** over the dedicated circuit:
+But both Azure and AWS also have public peering-style options where you can exchange public routes over the dedicated circuit. In Azure that is ExpressRoute Microsoft peering, and in AWS that is a Direct Connect public VIF.
 
-- **Azure ExpressRoute**: *Microsoft peering* (public services over the Microsoft backbone)
-- **AWS Direct Connect**: *public VIF* (public AWS services over the DX)
-
-Why you’d do it:
-- predictable latency and jitter vs the internet
-- avoid hairpinning through generic internet egress
-- improve the path to cloud SaaS / public endpoints where it matters
+Why you’d do it is straightforward: you get predictable latency and jitter versus the internet, you avoid hairpinning through generic internet egress, and you can improve the path to cloud SaaS and public endpoints where it matters.
 
 > Sidebar: public peering doesn’t magically make the services private.
 >
@@ -213,32 +204,17 @@ Why you’d do it:
 
 ### Summarisation (and the sharp edges)
 
-Summarisation is attractive because it:
-- reduces route table size
-- can make failover faster/cleaner
-- and is easier to reason about
+Summarisation is attractive because it reduces route table size, it can make failover faster and cleaner, and it is easier to reason about.
 
-But it has sharp edges:
-- you can accidentally blackhole traffic if you summarise a block that isn’t fully reachable in all failure modes
-- you can lose useful specificity for traffic engineering (more-specifics win)
+But it has sharp edges. You can accidentally blackhole traffic if you summarise a block that isn’t fully reachable in all failure modes, and you can lose useful specificity for traffic engineering because more-specifics win.
 
-A pragmatic approach is:
-- summarise where it’s *structurally true* (e.g., you really do own that block end-to-end),
-- keep de-aggregation for the cases where you need it deliberately (and document why).
+A pragmatic approach is to summarise where it’s structurally true (for example, where you really do own that block end-to-end), and to keep de-aggregation for the cases where you need it deliberately, and document why.
 
 ### Defaults
 
-Default routes are a great tool when used intentionally.
+Default routes are a great tool when used intentionally. In small branch designs, a default can be exactly what you want, “send everything to the core”. At a cloud edge, a default can be dangerous if it causes accidental internet breakout where you didn’t intend it, or asymmetric paths that make troubleshooting miserable.
 
-- In small branch designs, a default can be exactly what you want: “send everything to the core.”
-- At a cloud edge, a default can be dangerous if it causes:
-  - accidental internet breakout where you didn’t intend it, or
-  - asymmetric paths that make troubleshooting miserable.
-
-If you use defaults, treat them like any other route:
-- filter them explicitly
-- set their preference intentionally
-- test the failure mode (what happens when the preferred exit disappears?)
+If you use defaults, treat them like any other route. Filter them explicitly, set their preference intentionally, and test the failure mode (what happens when the preferred exit disappears?).
 
 ## 6) BGP path selection (the bits you actually use)
 
@@ -252,19 +228,13 @@ We’ll keep this vendor-neutral and focus on the knobs you’ll actually touch 
 
 When a router has multiple routes to the same destination prefix, it picks a “best” path by comparing attributes in a consistent order.
 
-In practice, for enterprise connectivity, you can think in three buckets:
-
-- **Things you set internally to steer *your outbound*** (e.g., LOCAL_PREF)
-- **Things you can signal to a neighbour to *influence inbound*** (e.g., MED, AS_PATH)
-- **Tie-breakers** (where BGP picks something stable when your policy doesn’t decide)
+In practice, for enterprise connectivity, you can think in three buckets: things you set internally to steer your outbound (for example, LOCAL_PREF), things you can signal to a neighbour to influence inbound (for example, MED and AS_PATH), and tie-breakers, where BGP picks something stable when your policy doesn’t decide.
 
 ### The three attributes you’ll use constantly
 
-- **LOCAL_PREF**: your strongest tool for choosing the outbound exit *inside your AS*.
-- **AS_PATH**: one of the few levers that naturally propagates beyond your first-hop peer.
-- **MED**: a hint to a neighbour, with limits.
+The three attributes you’ll use constantly are LOCAL_PREF, which is your strongest tool for choosing the outbound exit inside your AS, AS_PATH, which is one of the few levers that naturally propagates beyond your first-hop peer, and MED, which is a hint to a neighbour, with limits.
 
-> We’ll go deeper on how to use each of these in Sections 7 and 8.
+We’ll go deeper on how to use each of these in Sections 7 and 8.
 
 ### Real-world scenarios we’ll map onto these knobs
 
@@ -294,10 +264,7 @@ If you’re deciding which circuit you want to use to *leave your network*, BGP 
 LOCAL_PREF is an attribute you set **inside your AS** to express preference for one exit over another.
 Higher LOCAL_PREF wins.
 
-It’s popular for three reasons:
-- it’s deterministic
-- it’s simple to reason about
-- it doesn’t require you to play games with AS_PATH length
+It’s popular for three reasons: it’s deterministic, it’s simple to reason about, and it doesn’t require you to play games with AS_PATH length.
 
 > Sidebar: ECMP vs active/passive is often dictated by security appliances.
 >
@@ -307,15 +274,9 @@ It’s popular for three reasons:
 
 ### Pattern: prefer exit A, keep exit B as backup
 
-This is the bread-and-butter enterprise requirement.
+This is the bread-and-butter enterprise requirement. You learn the same (or overlapping) routes from two upstreams or two circuits, you want all outbound traffic to prefer circuit A, and if A fails you want traffic to move to B.
 
-- You learn the same (or overlapping) routes from two upstreams / two circuits.
-- You want all outbound traffic to prefer circuit A.
-- If A fails, you want traffic to move to B.
-
-Mechanically, you do this by:
-- matching the routes you learn from neighbour A and setting a higher LOCAL_PREF,
-- leaving neighbour B at a lower LOCAL_PREF.
+Mechanically, you do this by matching the routes you learn from neighbour A and setting a higher LOCAL_PREF, and leaving neighbour B at a lower LOCAL_PREF.
 
 ### IOS-XE example (set LOCAL_PREF higher for routes learned from preferred peer)
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -414,17 +414,92 @@ A few practical notes:
 
 ## 8) Influencing inbound traffic (enterprise reality)
 
+Inbound is where BGP stops feeling like “routing” and starts feeling like diplomacy.
+
+Outbound is easy: you choose which exit you use.
+Inbound is harder because you’re asking someone else (your peer) to choose a path *towards you*.
+
+That’s why you’ll often see enterprise designs that are:
+- **active/passive** (make the path obvious), or
+- heavily **provider-specific** (because the cleanest inbound levers are often communities).
+
 ### Why inbound is harder
-(TODO: you’re asking someone else to choose differently)
 
-### AS_PATH prepending
-(TODO)
+There are three reasons inbound traffic engineering is fundamentally more limited:
 
-### MED (when it’s honoured, and why it doesn’t travel)
-(TODO)
+1) **The decision happens somewhere else.**
+   Your router doesn’t pick the inbound path. The upstream network does.
+
+2) **BGP is policy-based.**
+   The upstream might prefer “their cheapest exit” or “their preferred region” over your hints.
+
+3) **Some attributes don’t travel.**
+   The two attributes people most want to use (LOCAL_PREF and MED) often don’t help beyond the first hop.
+
+So your inbound strategy usually falls into one of these buckets:
+- use a provider-supported knob (communities)
+- use a crude but portable signal (AS_PATH)
+- accept that “good enough” beats “perfect”
+
+### MED (when it’s honoured, and why it doesn’t travel far)
+
+MED (Multi-Exit Discriminator) is designed for a very specific situation:
+
+> “Dear neighbour AS, *if you have multiple ways to reach me*, here’s the one I’d like you to prefer.”
+
+In enterprise connectivity, MED is attractive because it’s conceptually neat:
+- you can tag routes advertised on circuit A with a lower MED (more preferred)
+- and tag routes advertised on circuit B with a higher MED (less preferred)
+
+But there are limitations you should assume unless you’ve validated the provider behaviour:
+
+- **MED is only meaningful to your direct neighbour.** It’s not a downstream steering mechanism.
+- Many networks only compare MEDs when the candidate paths are learned from **the same neighbouring AS**.
+  - If you’re multi-homed to different upstream ASNs, MED usually won’t help.
+- The neighbour can ignore MED completely, or override it with their own policy.
+
+So the safe enterprise posture is:
+- **use MED when you have two links to the same provider AS and you know they honour it**
+- don’t build a fragile design that depends on it without a test
+
+### AS_PATH prepending (crude, but it propagates)
+
+AS_PATH prepending is the hammer people reach for because it has one key property:
+
+- **AS_PATH travels.**
+
+If you make one path “look longer” by adding extra copies of your ASN, that signal can influence decisions not just in your direct neighbour, but further upstream.
+
+That said, it’s still not magic:
+- some networks have local policy that dominates AS_PATH length
+- once LOCAL_PREF or a community-based preference is set in the upstream, AS_PATH length might not matter
+
+A practical way to think about prepend:
+- it’s good for “prefer this circuit most of the time”, not “pin every prefix to a specific link forever”.
+
+### Putting it together: two links to the same provider
+
+This is the classic enterprise ask:
+
+- Outbound: prefer circuit A, keep B as backup (LOCAL_PREF)
+- Inbound: encourage the provider to send traffic to you via circuit A
+
+A pragmatic ordering is:
+
+1) If you have a provider-supported inbound knob (often communities): use that.
+2) If you’re dual-connected to the *same* provider AS and they honour MED: MED can work cleanly.
+3) If you need a portable signal that propagates: prepend on the less-preferred circuit.
+
+> Sidebar: there is no guarantee of perfect symmetry.
+>
+> Even when you do everything “right”, you can end up with a symmetric *intent* but asymmetric *reality*.
+> Failures, maintenance, hot-potato routing and upstream policy all get a vote.
 
 ### Communities (conceptual)
+
 BGP communities are one of the most useful “provider-supported knobs”, but they’re still *influence*, not control.
+
+They’re often the cleanest way to do inbound steering because the provider can map a community to an explicit internal policy (for example, changing local preference on their side).
 
 I’ve written a more detailed comparison of how Azure and AWS use communities here:
 https://www.simonpainter.com/community-comparison/

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -11,9 +11,15 @@ date: 2026-03-15
 draft: true
 ---
 
-BGP is the control plane that makes Direct Connect and ExpressRoute work.
+I used to joke that the cloud networking exams — AZ-700 for Azure, and AWS Advanced Networking — were mostly just *“BGP in a GUI”*.
 
-If you only ever touched BGP at an MPLS edge, you can still run successful cloud connectivity — but you need a better mental model of **what BGP is doing**, **how attributes affect path selection**, and **which knobs actually influence inbound vs outbound**.
+It’s not really true. Both exams cover a lot more than that: security, load balancers, DNS, design patterns… the works.
+
+But the joke exists for a reason: as soon as you get into hybrid connectivity and multi-cloud architecture, **BGP is everywhere**.
+
+And it’s not fair to assume that every enterprise network engineer has spent years living in BGP. Plenty of excellent network engineers can build entire careers with only a light touch of it (often just “peer to the MPLS provider and move on”).
+
+So this post is an explainer of the key BGP concepts that an enterprise network engineer needs to feel comfortable designing and operating **hybrid, multi-cloud connectivity** — where BGP plays its vital role.
 
 <!--truncate-->
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -54,7 +54,7 @@ In enterprise cloud connectivity that usually means your router in a CNF peering
 
 > **MSEE** (Microsoft Enterprise Edge): Microsoft’s routers on the ExpressRoute edge that you peer with.
 >
->**PE** (Provider Edge): the provider’s edge router, facing customer circuits.
+> **PE** (Provider Edge): the provider’s edge router, facing customer circuits.
 >
 > **CNF** (carrier neutral facility): a colocation site where you can cross-connect to multiple carriers, cloud on-ramps, and exchanges.
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -574,17 +574,87 @@ A cloud exchange is typically a **carrier neutral facility (CNF)** where you can
 - cloud provider connectivity (ExpressRoute / Direct Connect)
 - WAN connectivity (MPLS / SD-WAN)
 
+In practice, a CNF is where enterprise networking starts to look a little bit like “real internet engineering”… except you’re doing it inside a building with cross-connects.
+
 Assumption for the examples in this post:
 - you host **your own routers** in the exchange, and
 - the exchange provides **L2** to each cloud peer (so you run BGP directly with the cloud/provider routers).
 
-### Two-CNF diversity and ASN choices
+### Two-CNF diversity (why it’s common)
 
-#### Option A: single ASN across both CNFs
-(TODO: explain path selection options)
+A common pattern is to use **two CNFs** for physical and geographic diversity:
+- separate meet-me rooms
+- separate fibre paths
+- separate power domains / blast radius
+
+You then decide whether the design is:
+- **active/active northbound** (both CNFs have cloud peers up), or
+- **active/passive** (one CNF is preferred, the other is failover)
+
+As we mentioned earlier, active/passive is often dictated by the southbound architecture (stateful firewalls, NAT, or policy constraints that require symmetric flow).
+
+### ASN design choices at the CNF
+
+There are two common ways enterprises structure ASNs at the edge.
+
+#### Option A: single ASN across both CNFs (one enterprise AS)
+
+This is the “clean BGP” model.
+
+- Both CNF routers are in the same ASN.
+- You run eBGP to each cloud/provider peer.
+- You run iBGP between your CNF routers (and usually to the rest of your core).
+
+Why it’s nice:
+- **LOCAL_PREF works exactly how you expect** for choosing your outbound exit.
+- You can express “prefer CNF A for outbound, keep CNF B as backup” without AS_PATH games.
+- It tends to be easier to build deterministic failover.
+
+The trade-off:
+- you’re now in “iBGP design land” (full mesh vs route reflection, etc.).
 
 #### Option B: dual private ASNs (one per CNF)
-(TODO: explain why LOCAL_PREF and MED are AS-local / limited; why prepend is downstream-visible)
+
+This is an operationally popular model in enterprises because it feels like “two edges”.
+
+- CNF A is ASN 65001.
+- CNF B is ASN 65002.
+- Each CNF peers to the cloud/provider ASN.
+- Somewhere downstream you have to reconnect those worlds (often another BGP hop inside your enterprise).
+
+Why people do it:
+- it keeps the edges conceptually independent
+- eBGP loop prevention can simplify some designs
+
+But it comes with important limitations for end-to-end traffic engineering:
+
+- **LOCAL_PREF is not transitive.**
+  - It’s your internal preference inside one ASN.
+  - If CNF A and CNF B are different ASNs, LOCAL_PREF you set in one doesn’t automatically help the other.
+
+- **MED is not a downstream steering tool.**
+  - Even when honoured, it’s a hint to your neighbour and typically scoped to comparisons within the same neighbour AS.
+
+- **AS_PATH does propagate.**
+  - That’s why prepend often becomes the “portable lever” in dual-AS edge designs.
+
+### Putting it together: “two private ASNs to one remote ASN”
+
+This is the scenario you called out earlier:
+
+- you have two edge ASNs (one per CNF)
+- both peer to a single remote ASN (provider/cloud)
+- you want downstream parts of *your* enterprise (and sometimes other connected networks) to follow the right end-to-end path
+
+The key mental model:
+
+- if the decision is happening **inside one of your ASNs**, LOCAL_PREF is king.
+- if the decision is happening **outside your AS**, AS_PATH and provider-supported communities are the tools that can travel.
+
+This is also where it becomes crucial to separate:
+- “what do I want for outbound?” (easy)
+- “what do I want for inbound?” (hard)
+- “what is my failure mode?” (the thing that makes the design real)
 
 ## 11) Safety rails (the section that saves outages)
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -169,32 +169,6 @@ Why this matters for the cloud journey: this is the closest mental model to DX/E
 > - the provider is **not** doing your inter-site route exchange for you; _your BGP_ is.
 >
 > This pattern is conceptually closer to “running your own WAN overlay” than to classic managed MPLS L3VPN routing.
->
-> ```mermaid
-> %%{init: {'theme':'neutral','flowchart':{'curve':'basis'},'themeVariables':{'fontFamily':'Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial'}}}%%
-> flowchart LR
->   classDef enterprise fill:#E8F1FF,stroke:#2F6FED,stroke-width:1px,color:#0B1F44;
->   classDef provider fill:#FFF3E0,stroke:#F59E0B,stroke-width:1px,color:#3B2F00;
->   classDef edge fill:#F3E8FF,stroke:#8B5CF6,stroke-width:1px,color:#2E1065;
->
->   subgraph SiteA[Site A]
->     CE1[CE Router]:::edge
->   end
->
->   subgraph Provider[Provider MPLS Underlay]
->     MPLS[(Transport only)]:::provider
->   end
->
->   subgraph SiteB[Site B]
->     CE2[CE Router]:::edge
->   end
->
->   CE1 -- BGP adjacency --> CE2
->   CE1 -. IP reachability via underlay .- MPLS
->   CE2 -. IP reachability via underlay .- MPLS
->
->   %% Customer CEs run the control plane; provider provides reachability.
-> ```
 
 ### ASNs in MPLS enterprise designs
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -506,7 +506,61 @@ https://www.simonpainter.com/community-comparison/
 
 ## 9) Communities (the provider-supported knobs)
 
-(TODO: keep conceptual; point to AWS/Azure docs and the comparison post above)
+BGP communities are just tags.
+That sounds underwhelming, but it’s exactly why they’re powerful.
+
+A community is a value (traditionally a 32-bit `X:Y` format, and in modern networks often *large communities*) that a router can attach to a route.
+The receiving network can then match on that tag and apply policy.
+
+In other words:
+- **you tag routes with intent**
+- **your peer maps that tag to behaviour**
+
+That’s why communities are often the cleanest inbound influence mechanism.
+You’re not trying to “beat” someone else’s decision process; you’re asking them to apply a documented policy.
+
+### The key rule: influence, not control
+
+Communities don’t override the fact that BGP crosses administrative boundaries.
+The peer still decides what they honour.
+
+Treat communities as:
+- a supported API into your provider’s policy, not
+- a guaranteed steering mechanism.
+
+### Common community categories you’ll encounter
+
+The exact values are provider-specific, but the *themes* repeat:
+
+- **Scope / propagation control**
+  - e.g., `NO_EXPORT` (RFC 1997) or “don’t advertise this beyond region X”.
+
+- **Preference / traffic engineering**
+  - “prefer this path more/less” (often implemented as a local preference change on the provider side).
+
+- **Blackholing** (in some designs)
+  - “discard traffic to this prefix at the edge” (useful for DDoS response when supported).
+
+- **Service / region classification**
+  - especially for public-cloud public prefixes (filter by service, region, sovereign cloud, etc.).
+
+### AWS vs Azure: don’t assume they work the same
+
+AWS and Azure both use communities heavily, but the models differ.
+
+Rather than duplicating provider tables here, I’ve written up a comparison (including examples like NO_EXPORT usage, regional scoping, and preference communities) in a dedicated post:
+
+https://www.simonpainter.com/community-comparison/
+
+### Practical advice
+
+- Start with the provider’s documentation for the specific connection type (DX public/private VIF; ER private/Microsoft peering).
+- Implement communities in code/policy with the same discipline as firewall rules:
+  - version control,
+  - review,
+  - explicit intent,
+  - and testing.
+- Prefer communities over “clever” AS_PATH games when the provider supports the behaviour you need.
 
 ## 10) Cloud exchange / carrier neutral facility (CNF) patterns
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -420,6 +420,7 @@ A few practical notes:
 
 ## TODO: style pass
 - Replace **em dashes (—)** with commas or semicolons where appropriate.
+- Reduce **bulleted lists**; prefer prose paragraphs (comma-separated lists where it reads well).
 
 ## 8) Influencing inbound traffic (enterprise reality)
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -83,10 +83,7 @@ That’s fine, but it can leave you with some slightly warped assumptions, becau
 
 ### Managed CEs (you might never have seen the BGP config)
 
-Plenty of enterprises buy **managed CE routers**. In that model:
-- the provider owns the config,
-- you may only see a handoff (LAN interface / VLAN),
-- and you might never touch BGP at all.
+Plenty of enterprises buy **managed CE routers**. In that model the provider owns the config, you may only see a handoff (LAN interface or VLAN), and you might never touch BGP at all.
 
 Mechanically, BGP is still often involved somewhere, but it’s just **not your problem** until the day you add cloud connectivity, and suddenly it is.
 
@@ -96,11 +93,7 @@ There are a few common ways MPLS WAN providers present routing. The exact implem
 
 #### Pattern A: PE/CE eBGP (provider AS visible)
 
-This is the “textbook” model.
-
-- Your CE runs **eBGP to the provider PE**.
-- The provider PE is in **the provider’s ASN**, so you see the provider AS in the AS_PATH (or at least you *can*).
-- Your routes are imported into the provider’s MPLS VPN routing domain and distributed to other sites.
+This is the “textbook” model. Your CE runs eBGP to the provider PE. The provider PE is in the provider’s ASN, so you see the provider AS in the AS_PATH (or at least you can). Your routes are imported into the provider’s MPLS VPN routing domain and distributed to other sites.
 
 Why this matters for the cloud journey: this is the closest mental model to DX/ER peering.
 
@@ -325,17 +318,13 @@ protocols {
 }
 ```
 
-A few practical notes:
-- In real configs you’ll almost always include **explicit route filters** (prefix-lists) alongside these policies.
-- If you want active/active, LOCAL_PREF can still be used; you just set them equal, and rely on other mechanisms (or ECMP capability) to load-share.
+A few practical notes: in real configs you’ll almost always include explicit route filters (prefix-lists) alongside these policies. If you want active/active, LOCAL_PREF can still be used; you just set them equal, and rely on other mechanisms (or ECMP capability) to load-share.
 
 ## TODO: diagrams
-- Add **Mermaid diagrams** for each architectural example/pattern in this post (MPLS patterns, dual circuits, CNF designs, etc.).
+Add Mermaid diagrams for each architectural example or pattern in this post (MPLS patterns, dual circuits, CNF designs, and so on).
 
 ## TODO: style pass
-- Replace em dashes (the long dash character) with commas or semicolons where appropriate.
-- Reduce **bulleted lists**; prefer prose paragraphs (comma-separated lists where it reads well).
-- Use the **Oxford comma** in all comma-separated lists.
+Replace em dashes (the long dash character) with commas or semicolons where appropriate. Reduce bulleted lists, and prefer prose paragraphs (comma-separated lists where it reads well). Use the Oxford comma in all comma-separated lists.
 
 ## 8) Influencing inbound traffic (enterprise reality)
 
@@ -494,25 +483,17 @@ This is also where it becomes crucial to separate what you want for outbound (ea
 
 If you take only one operational lesson from BGP, take this:
 
-- **BGP doesn’t make you a transit network. Your policies do.**
+**BGP doesn’t make you a transit network. Your policies do.**
 
-The most common way enterprises accidentally become transit is simple:
-- you learn routes from provider A,
-- you learn routes from provider B,
-- and you mistakenly export A’s routes to B (and/or vice versa).
+The most common way enterprises accidentally become transit is simple. You learn routes from provider A, you learn routes from provider B, and you mistakenly export A’s routes to B (and/or vice versa).
 
-That’s rarely desirable.
-It can also become expensive fast.
+That’s rarely desirable, and it can also become expensive fast.
 
-The fix is boring and effective:
-- strict **import filters** (what you accept)
-- strict **export filters** (what you advertise)
+The fix is boring and effective: strict import filters (what you accept), and strict export filters (what you advertise).
 
 #### Example: dual-provider internet peering (don’t become transit)
 
-In this pattern you receive routes from two upstreams, but you only ever advertise:
-- your own prefixes, and
-- (optionally) a default or a small set of aggregates you explicitly intend to originate.
+In this pattern you receive routes from two upstreams, but you only ever advertise your own prefixes, and optionally a default or a small set of aggregates you explicitly intend to originate.
 
 **IOS-XE (illustrative)**
 ```ios
@@ -610,20 +591,11 @@ If you’re peering with an upstream that can legitimately send you huge tables 
 
 ### Route refresh / soft reconfig basics
 
-Modern BGP gives you ways to change policy without bouncing the session.
-This matters operationally because:
-- bouncing a session can cause unnecessary convergence churn
-- and on some designs it can cause traffic loss while paths re-learn
+Modern BGP gives you ways to change policy without bouncing the session. This matters operationally because bouncing a session can cause unnecessary convergence churn, and on some designs it can cause traffic loss while paths re-learn.
 
-Two concepts you’ll see:
+Two concepts you’ll see are Route Refresh, a capability where you can ask a neighbour to resend routes after you change policy, and soft reconfiguration, which keeps enough state to re-evaluate routes against new policy without a hard reset.
 
-- **Route Refresh**: a capability where you can ask a neighbour to resend routes after you change policy.
-- **Soft reconfiguration**: keeping enough state to re-evaluate routes against new policy without a hard reset.
-
-The exact commands differ (IOS-XE vs JunOS), but the operational goal is the same:
-- change filter/policy
-- refresh routes
-- confirm the new bestpaths
+The exact commands differ (IOS-XE versus JunOS), but the operational goal is the same: change filter or policy, refresh routes, and confirm the new bestpaths.
 
 If your platform supports route refresh, use it.
 If it doesn’t, you’ll end up doing some kind of clear/reset; just do it intentionally, and during a safe window.
@@ -634,22 +606,11 @@ This post is intentionally vendor-neutral, but cloud connectivity has a few “c
 
 ### What’s different for DX/ER vs MPLS peering
 
-Some practical differences you’ll feel:
+Some practical differences you’ll feel are that you’re peering to a cloud service, not a human-run PE router, so behaviours are documented but you don’t get to ring the NOC and ask them to tweak a knob “just this once”. Route limits are also real, with hard limits on prefixes and routes in some cloud constructs, which makes filtering, summarisation, and intentional route design more important.
 
-- **You’re peering to a cloud service, not a human-run PE router.**
-  - behaviours are documented, but you don’t get to ring the NOC and ask them to tweak a knob “just this once”.
+Public peering options exist too, and they come with sharp edges. DX public VIF and ER Microsoft peering can be great for predictable paths to public services, but they’re also where you really don’t want to accidentally export something that turns you into transit.
 
-- **Route limits are real.**
-  - there are hard limits on prefixes and routes in some cloud constructs.
-  - this makes filtering/summarisation and intentional route design more important.
-
-- **Public peering options exist (and come with sharp edges).**
-  - DX public VIF / ER Microsoft peering can be great for predictable paths to public services.
-  - they’re also where you really don’t want to accidentally export something that turns you into transit.
-
-- **Availability patterns are “product-shaped”.**
-  - you’ll often have multiple BGP sessions per circuit, dual circuits, and region/site diversity patterns.
-  - the BGP knobs are the same; the constraints around them are not.
+Finally, availability patterns are “product-shaped”. You’ll often have multiple BGP sessions per circuit, dual circuits, and region and site diversity patterns. The BGP knobs are the same, but the constraints around them are not.
 
 ### Route Server (brief pointer)
 
@@ -662,10 +623,6 @@ https://www.simonpainter.com/transit-route-prevention/
 
 BGP can look intimidating because the internet uses it, and the internet is huge.
 
-But enterprise cloud connectivity only needs a subset:
-- understand the eBGP vs iBGP boundary
-- know which attributes are useful in practice (LOCAL_PREF, AS_PATH, MED)
-- use communities when the provider documents them
-- and put safety rails around import/export so you don’t leak routes or accidentally become transit
+But enterprise cloud connectivity only needs a subset. Understand the eBGP versus iBGP boundary, know which attributes are useful in practice (LOCAL_PREF, AS_PATH, and MED), use communities when the provider documents them, and put safety rails around import and export so you don’t leak routes, or accidentally become transit.
 
 If you get those right, you’ll be able to design hybrid multi-cloud connectivity that behaves predictably, and when it doesn’t, you’ll know where to look.

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -469,6 +469,19 @@ This post includes Mermaid diagrams for the key architectural patterns. If I’v
 - Add a short sidebar on **AWS Route Server vs Azure Route Server**, to head off naming confusion and emphasise the transitive versus non-transitive difference (and why this matters for appliance failover and routing design): https://www.simonpainter.com/aws-route-server/
 - Optionally add a callout that AWS Route Server is primarily active/passive NVA failover orchestration in a single VPC, while Azure Route Server is closer to “BGP as a Service”, and point readers to the post above for the deeper comparison.
 
+- Add an **ExpressRoute BGP essentials** callout that makes the BGP behaviour explicit (because the Microsoft Learn module underplays it), covering:
+  - each ExpressRoute peering is delivered via **a pair of independent eBGP sessions** (redundant);
+  - **prefix limit exceed** behavior (session termination) and why monitoring matters;
+  - fixed Microsoft-side **BGP timers** (keepalive/hold) and the recommendation to use **BFD** for faster failover;
+  - the boundary that route filtering is primarily an **on-prem edge** responsibility, and Azure UDRs are not dynamic/BGP;
+  - Microsoft peering specifics: no routes until a **route filter** is attached.
+
+Reference docs to cite:
+- https://learn.microsoft.com/en-us/azure/expressroute/expressroute-circuit-peerings
+- https://learn.microsoft.com/en-us/azure/expressroute/expressroute-faqs
+- https://learn.microsoft.com/en-us/azure/expressroute/design-architecture-for-resiliency
+- https://learn.microsoft.com/en-us/azure/troubleshoot/azure/expressroute/expressroute-troubleshooting-network-performance
+
 ## Influencing inbound traffic (enterprise reality)
 
 Inbound is where BGP stops feeling like “routing” and starts feeling like diplomacy.

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -944,3 +944,5 @@ BGP can look intimidating because the internet uses it, and the internet is huge
 But enterprise cloud connectivity only needs a subset. Understand the eBGP versus iBGP boundary, know which attributes are useful in practice (LOCAL_PREF, AS_PATH, and MED), use communities when the provider documents them, and put safety rails around import and export so you don’t leak routes, or accidentally become transit.
 
 If you get those right, you’ll be able to design hybrid multi-cloud connectivity that behaves predictably, and when it doesn’t, you’ll know where to look.
+
+A practical starting point: audit your prefix-lists and export policies first. That's where the most damaging mistakes happen, and it's where a clean baseline gives you room to iterate on everything else.

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -746,7 +746,9 @@ A pragmatic enterprise approach is to set max-prefix on every eBGP peer, to size
 >
 > The extra sting is that BT don’t necessarily auto-timeout and recover quickly. Even after you fix the policy, you may need to raise a priority support ticket to get the peering reset.
 >
-> The lesson is simple, and painfully memorable: max-prefix is there to save you, but your filters are what stop you needing the ticket in the first place.
+> The lesson is simple, and painfully memorable. BT are protecting themselves aggressively from customers accidentally, or deliberately, advertising too many routes and filling up router memory.
+>
+> A core principle of BGP is that it’s typically at your perimeter, so you should not trust the motives or capabilities of a peer. Always apply your own import policy, export policy, and limits to protect yourself.
 
 If you’re peering with an upstream that can legitimately send you huge tables (e.g., full routes), max-prefix is still useful; you just size it appropriately.
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -108,21 +108,21 @@ This is the “textbook” model.
 
 Why this matters for the cloud journey: this is the closest mental model to DX/ER peering.
 
-#### Pattern B: CE–CE peering over MPLS (customer edges peer with each other)
+#### Pattern B (sidebar): CE–CE peering over MPLS (customer edges peer with each other)
 
-This is **not the typical MPLS model** — most MPLS WANs are built as a many-to-many L3VPN where you peer to the provider and the provider does the route distribution.
-
-That said, I *have* seen real-world deployments where the MPLS network is treated as **a transport underlay**, and the **customer edge routers form BGP adjacencies with each other** (directly or via some kind of rendezvous).
-
-What it looks like from the customer’s point of view:
-- Site A CE has BGP neighbours that are *other customer CEs*.
-- The provider ASN may not appear in the AS_PATH (because the provider isn’t acting as a BGP hop in your control plane).
-
-What has to be true for it to work:
-- The provider must provide **IP reachability between CEs** (it’s effectively giving you a routed point-to-point / any-to-any service), and
-- the provider is **not** doing your inter-site route exchange for you — *your BGP* is.
-
-This pattern is conceptually closer to “running your own WAN overlay” than to classic managed MPLS L3VPN routing.
+> This is **not the typical MPLS model** — most MPLS WANs are built as a many-to-many L3VPN where you peer to the provider and the provider does the route distribution.
+>
+> That said, I *have* seen real-world deployments where the MPLS network is treated as **a transport underlay**, and the **customer edge routers form BGP adjacencies with each other**.
+>
+> What it looks like from the customer’s point of view:
+> - Site A CE has BGP neighbours that are *other customer CEs*.
+> - The provider ASN may not appear in the AS_PATH (because the provider isn’t acting as a BGP hop in your control plane).
+>
+> What has to be true for it to work:
+> - The provider must provide **IP reachability between CEs** (it’s effectively giving you a routed any-to-any service), and
+> - the provider is **not** doing your inter-site route exchange for you — *your BGP* is.
+>
+> This pattern is conceptually closer to “running your own WAN overlay” than to classic managed MPLS L3VPN routing.
 
 ### ASNs in MPLS enterprise designs
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -335,7 +335,7 @@ The important nuance is that the BGP path selection algorithm only runs when you
 
 That’s one of the reasons providers often enforce a minimum, maximum, or fixed acceptable prefix length in their routing policy. They’re trying to keep the routing domain sane, and they’re also trying to avoid customers using more-specific prefixes as a cheap trick to bypass policy and traffic engineering.
 
-If you want the rationale for why prefix length wins before any BGP attribute, and why we shouldn’t abuse it, this post is my attempt to explain: [Longest Prefix Matching](https://www.simonpainter.com/longest-prefix-matching/).
+If you want the rationale for why prefix length wins before any BGP attribute, and why we shouldn’t abuse it, this post is my attempt to explain: [Longest Prefix Matching](longest-prefix-matching.md).
 
 Vendor note: the exact tie-break order differs slightly between implementations, and there are settings that can change it. Junos has a good write-up here, including its default MED comparison behaviour and the options that alter it: [Junos BGP Documentation](https://www.juniper.net/documentation/us/en/software/junos/vpn-l2/bgp/topics/concept/routing-protocols-address-representation.html)
 
@@ -908,7 +908,7 @@ Azure Route Server is closer to “BGP as a Service”, it peers using standard 
 
 AWS Route Server is a more specialised tool, it is primarily about orchestrating active/passive appliance failover by manipulating specific route tables, and it is deliberately non-transitive.
 
-If you want the deeper comparison (and the philosophy behind the difference), I wrote it up here: [AWS Route Server vs Azure Route Server](https://www.simonpainter.com/aws-route-server/)
+If you want the deeper comparison (and the philosophy behind the difference), I wrote it up here: [AWS Route Server vs Azure Route Server](aws-route-server.md)
 :::
 
 ## Wrapping up

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -150,7 +150,67 @@ This exact idea shows up again in cloud connectivity designs when you’re decid
 
 ## 4) Peering relationships in enterprise cloud connectivity
 
-(TODO: on-prem edge ↔ exchange/provider ↔ cloud; private vs public ASN realities)
+If you strip away the product names, enterprise cloud connectivity is mostly just this:
+
+- you have some internal prefixes on one side (data centres, campus, branch sites)
+- you have some cloud prefixes on the other side (VNets/VPCs and their attached services)
+- and you use BGP to exchange routes between them over a private transport
+
+The transport could be:
+- MPLS / SD-WAN underlay
+- ExpressRoute / Direct Connect
+- a cloud exchange in a CNF (where you’ve got your own routers and L2 handoff to the peers)
+
+### What’s actually peering with what?
+
+In the model we’re using for this post:
+
+- Your routers sit in one (or two) CNFs.
+- You have L2 to each provider peer.
+- You run **eBGP** to:
+  - Azure (ExpressRoute private peering)
+  - AWS (Direct Connect private VIF)
+  - optionally your WAN provider(s) if you’re also aggregating MPLS/SD-WAN there.
+
+On the enterprise side, you then need to decide how those routes get back into the rest of your network:
+- iBGP to a core pair / route reflectors, or
+- redistribution into an IGP (with all the caveats that implies).
+
+### Private ASN vs public ASN (enterprise reality)
+
+This tends to confuse people because “ASN” sounds like an ISP thing.
+
+- **Private ASNs** are extremely common in enterprise designs.
+  - They’re fine as long as you understand where they are allowed to appear.
+- **Public ASNs** are usually only needed when you need to present a stable identity across the wider internet routing domain.
+  - Most enterprises don’t need that for private connectivity to cloud.
+
+The pragmatic rule: use a private ASN unless you have a reason not to.
+
+### One ASN everywhere vs multiple ASNs
+
+This is where your MPLS experience is directly relevant.
+
+- **One ASN everywhere** (single enterprise ASN) can be clean.
+  - It pairs naturally with iBGP inside your network.
+  - But you need to design around loop prevention when routes traverse boundaries.
+
+- **Multiple ASNs** (per site / per edge) can be operationally convenient.
+  - It makes eBGP loop-prevention “just work” because each edge is a distinct AS.
+  - It does, however, complicate how far certain attributes can help you (we’ll come back to this in the CNF section).
+
+### A note on “influence vs control”
+
+Anything that crosses an AS boundary is, by definition, a negotiation.
+
+You can usually control your own side completely.
+You can often influence your peer.
+But you rarely control what happens **beyond** your peer.
+
+That’s why a lot of BGP guidance boils down to:
+- keep your intent simple,
+- apply safety rails,
+- and don’t rely on a single knob (especially for inbound) unless you’ve validated the provider behaviour.
 
 ## 5) Route advertisement basics (what you advertise and why)
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -50,10 +50,7 @@ Cloud connectivity tends to drag iBGP into the conversation because you suddenly
 
 eBGP is what you run between your network and someone else’s.
 
-In enterprise cloud connectivity that usually means:
-- your router in a CNF peering with an **ExpressRoute** MSEE or **Direct Connect** router,
-- your router peering with an ISP,
-- your router peering with a managed MPLS provider PE.
+In enterprise cloud connectivity that usually means your router in a CNF peering with an **ExpressRoute** MSEE or **Direct Connect** router, your router peering with an ISP, or your router peering with a managed MPLS provider PE.
 
 The important enterprise mental model is: **eBGP is where the AS boundary is real**.
 Across that boundary you can exchange routes, and you can *influence* the other side, but you don’t get to enforce how they do their internal routing.
@@ -65,10 +62,7 @@ iBGP is what you run when you have multiple routers in **the same ASN** that nee
 In the simplest cloud edge, you might not need iBGP at all (one router, one peering).
 As soon as you add redundancy, iBGP becomes the clean way to make your edge behave like a single logical system:
 
-- Two edge routers in the same site (active/active)
-- Two CNFs (diverse meet-me rooms)
-- Two provider circuits (separate peers)
-- Two clouds (Azure + AWS)
+Typical triggers are two edge routers in the same site (active/active), two CNFs (diverse meet-me rooms), two provider circuits (separate peers), or two clouds (Azure and AWS).
 
 You *can* avoid iBGP by doing weird things (like re-advertising routes between eBGP peers and hoping loop prevention doesn’t bite you), but iBGP is usually the right tool.
 
@@ -78,11 +72,7 @@ You *can* avoid iBGP by doing weird things (like re-advertising routes between e
 
 ### Why you care
 
-Because **your operational knobs behave differently depending on where you are**:
-
-- **LOCAL_PREF** is your best “pick the outbound exit” tool, but it’s **only meaningful inside your AS**.
-- **MED** is, at best, a **hint to a neighbour** and typically only compared in narrow conditions.
-- **AS_PATH prepending** is crude, but it’s one of the few signals that naturally propagates beyond your first-hop peer.
+Because **your operational knobs behave differently depending on where you are**. LOCAL_PREF is your best “pick the outbound exit” tool, but it’s only meaningful inside your AS. MED is, at best, a hint to a neighbour, and it is typically only compared in narrow conditions. AS_PATH prepending is crude, but it’s one of the few signals that naturally propagates beyond your first-hop peer.
 
 If you understand the eBGP/iBGP boundary, the rest of BGP becomes much less mysterious.
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -150,7 +150,7 @@ flowchart LR
   %% Provider distributes customer routes inside the VPN routing domain.
 ```
 
-Why this matters for the cloud journey: this is the closest mental model to DX/ER peering.
+Why this matters for the cloud journey: this is the closest mental model to Direct Connect/ExpressRoute peering.
 
 ### Pattern B (sidebar): CE–CE peering over MPLS (customer edges peer with each other)
 
@@ -231,8 +231,8 @@ flowchart LR
   end
 
   subgraph Cloud[Cloud Providers]
-    AZ[Azure ER Peer]:::cloud
-    AWS[AWS DX Peer]:::cloud
+    AZ[Azure ExpressRoute Peer]:::cloud
+    AWS[AWS Direct Connect Peer]:::cloud
   end
 
   Core --> Sites
@@ -587,7 +587,7 @@ Rather than duplicating provider tables here, I’ve [written up a comparison](c
 
 ### Practical advice
 
-Start with the provider’s documentation for the specific connection type (DX public or private VIF, and ER private or Microsoft peering). Implement communities in code and policy with the same discipline as firewall rules, including version control, review, explicit intent, and testing. Prefer communities over “clever” AS_PATH games when the provider supports the behaviour you need.
+Start with the provider’s documentation for the specific connection type (Direct Connect public or private VIF, and ExpressRoute private or Microsoft peering). Implement communities in code and policy with the same discipline as firewall rules, including version control, review, explicit intent, and testing. Prefer communities over “clever” AS_PATH games when the provider supports the behaviour you need.
 
 :::note Prove your resiliency, don’t just design it
 BGP failover only matters if you’ve tested it. AWS provides guidance and tooling for deliberately failing over Direct Connect virtual interfaces, which makes it easier to run proper game-days.
@@ -633,8 +633,8 @@ flowchart LR
   end
 
   subgraph Clouds[Cloud peers]
-    AZ[Azure ER peer]:::cloud
-    AWS[AWS DX peer]:::cloud
+    AZ[Azure ExpressRoute peer]:::cloud
+    AWS[AWS Direct Connect peer]:::cloud
   end
 
   Core -- iBGP / internal --> E1
@@ -820,7 +820,7 @@ protocols {
 
 The same principle applies to **public cloud public-peering** models:
 
-- **DX public VIF** and **ER Microsoft peering** are _not_ a place you want to accidentally become transit.
+- **Direct Connect public VIF** and **ExpressRoute Microsoft peering** are _not_ a place you want to accidentally become transit.
 - If you’re receiving public prefixes from the provider, be deliberate about what you export back.
 
 On the other hand, in some **private multi-cloud CNF** designs, you might _deliberately_ act as a transit:
@@ -885,11 +885,11 @@ If it doesn’t, you’ll end up doing some kind of clear/reset; just do it inte
 
 This post is intentionally vendor-neutral, but cloud connectivity has a few “cloud-shaped” differences that are worth keeping in mind.
 
-### What’s different for DX/ER vs MPLS peering
+### What’s different for Direct Connect/ExpressRoute vs MPLS peering
 
 Some practical differences you’ll feel are that you’re peering to a cloud service, not a human-run PE router, so behaviours are documented but you don’t get to ring the NOC and ask them to tweak a knob “just this once”. Route limits are also real, with hard limits on prefixes and routes in some cloud constructs, which makes filtering, summarisation, and intentional route design more important.
 
-Public peering options exist too, and they come with sharp edges. DX public VIF and ER Microsoft peering can be great for predictable paths to public services, but they’re also where you really don’t want to accidentally export something that turns you into transit.
+Public peering options exist too, and they come with sharp edges. Direct Connect public VIF and ExpressRoute Microsoft peering can be great for predictable paths to public services, but they’re also where you really don’t want to accidentally export something that turns you into transit.
 
 Finally, availability patterns are “product-shaped”. You’ll often have multiple BGP sessions per circuit, dual circuits, and region and site diversity patterns. The BGP controls are the same, but the constraints around them are not.
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -110,22 +110,27 @@ There are a few common ways MPLS WAN providers present routing. The exact implem
 This is the “textbook” model. Your CE runs eBGP to the provider PE. The provider PE is in the provider’s ASN, so you see the provider AS in the AS_PATH (or at least you can). Your routes are imported into the provider’s MPLS VPN routing domain and distributed to other sites.
 
 ```mermaid
+%%{init: {'theme':'neutral','flowchart':{'curve':'basis'},'themeVariables':{'fontFamily':'Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial'}}}%%
 flowchart LR
+  classDef enterprise fill:#E8F1FF,stroke:#2F6FED,stroke-width:1px,color:#0B1F44;
+  classDef provider fill:#FFF3E0,stroke:#F59E0B,stroke-width:1px,color:#3B2F00;
+  classDef edge fill:#F3E8FF,stroke:#8B5CF6,stroke-width:1px,color:#2E1065;
+
   subgraph SiteA[Site A]
-    CE1[CE Router]
-    LAN1[LAN prefixes]
+    LAN1[LAN prefixes]:::enterprise
+    CE1[CE Router]:::edge
     LAN1 --> CE1
   end
 
   subgraph Provider[Provider MPLS Core]
-    PE1[PE Router]
-    MPLS[(MPLS / L3VPN Core)]
-    PE2[PE Router]
+    PE1[PE Router]:::provider
+    MPLS[(MPLS / L3VPN Core)]:::provider
+    PE2[PE Router]:::provider
   end
 
   subgraph SiteB[Site B]
-    CE2[CE Router]
-    LAN2[LAN prefixes]
+    CE2[CE Router]:::edge
+    LAN2[LAN prefixes]:::enterprise
     CE2 --> LAN2
   end
 
@@ -133,7 +138,7 @@ flowchart LR
   PE1 --> MPLS --> PE2
   PE2 -- eBGP (PE/CE) --> CE2
 
-  %% provider distributes customer routes inside the VPN routing domain
+  %% Provider distributes customer routes inside the VPN routing domain.
 ```
 
 Why this matters for the cloud journey: this is the closest mental model to DX/ER peering.
@@ -189,32 +194,37 @@ That transport could be an MPLS or SD-WAN underlay, ExpressRoute or Direct Conne
 In the model we’re using for this post, your routers sit in one (or two) CNFs, you have L2 to each provider peer, and you run eBGP to Azure (ExpressRoute private peering), AWS (Direct Connect private VIF), and optionally your WAN provider(s) if you’re also aggregating MPLS or SD-WAN there.
 
 ```mermaid
-flowchart TB
+%%{init: {'theme':'neutral','flowchart':{'curve':'basis'},'themeVariables':{'fontFamily':'Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial'}}}%%
+flowchart LR
+  classDef enterprise fill:#E8F1FF,stroke:#2F6FED,stroke-width:1px,color:#0B1F44;
+  classDef cloud fill:#E7F8EF,stroke:#10B981,stroke-width:1px,color:#05361F;
+  classDef edge fill:#F3E8FF,stroke:#8B5CF6,stroke-width:1px,color:#2E1065;
+
+  subgraph Enterprise[Enterprise]
+    Core[Core / RR / IGP]:::enterprise
+    Sites[DCs, campuses, and branches]:::enterprise
+  end
+
   subgraph CNF[Cloud Exchange / CNF]
-    ER1[Edge Router A]
-    ER2[Edge Router B]
+    ER1[Edge Router A]:::edge
+    ER2[Edge Router B]:::edge
   end
 
   subgraph Cloud[Cloud Providers]
-    AZ[Azure ER Peer]
-    AWS[AWS DX Peer]
+    AZ[Azure ER Peer]:::cloud
+    AWS[AWS DX Peer]:::cloud
   end
 
-  subgraph Enterprise[Enterprise Network]
-    Core[Core / RR / IGP]
-    Sites[DCs, campuses, branches]
-  end
+  Core --> Sites
+  Core -- iBGP / redistribute --> ER1
+  Core -- iBGP / redistribute --> ER2
 
   ER1 -- eBGP --> AZ
   ER1 -- eBGP --> AWS
   ER2 -- eBGP --> AZ
   ER2 -- eBGP --> AWS
 
-  ER1 -- iBGP / redistribute --> Core
-  ER2 -- iBGP / redistribute --> Core
-  Core --> Sites
-
-  %% CNF provides L2 handoff to the cloud peers
+  %% CNF provides an L2 handoff to the cloud peers.
 ```
 
 On the enterprise side, you then need to decide how those routes get back into the rest of your network. That usually means iBGP to a core pair or route reflectors, or redistribution into an IGP (with all the caveats that implies).
@@ -354,13 +364,18 @@ It’s popular for three reasons: it’s deterministic, it’s simple to reason 
 This is the bread-and-butter enterprise requirement. You learn the same (or overlapping) routes from two upstreams or two circuits, you want all outbound traffic to prefer circuit A, and if A fails you want traffic to move to B.
 
 ```mermaid
+%%{init: {'theme':'neutral','flowchart':{'curve':'basis'},'themeVariables':{'fontFamily':'Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial'}}}%%
 flowchart LR
-  LAN[Enterprise prefixes] --> R[Your Router]
-  R -- eBGP --> ISP1[Provider / Cloud Peer A]
-  R -- eBGP --> ISP2[Provider / Cloud Peer B]
+  classDef enterprise fill:#E8F1FF,stroke:#2F6FED,stroke-width:1px,color:#0B1F44;
+  classDef provider fill:#FFF3E0,stroke:#F59E0B,stroke-width:1px,color:#3B2F00;
+  classDef edge fill:#F3E8FF,stroke:#8B5CF6,stroke-width:1px,color:#2E1065;
 
-  %% Outbound: set higher LOCAL_PREF on routes learned via A
-  %% Failover: when A withdraws, B remains
+  LAN[Enterprise prefixes]:::enterprise --> R[Your edge router]:::edge
+  R -- eBGP --> ISP1[Peer A]:::provider
+  R -- eBGP --> ISP2[Peer B]:::provider
+
+  %% Outbound: set higher LOCAL_PREF on routes learned via Peer A.
+  %% Failover: when A withdraws, B remains.
 ```
 
 Mechanically, you do this by matching the routes you learn from neighbour A and setting a higher LOCAL_PREF, and leaving neighbour B at a lower LOCAL_PREF.
@@ -472,16 +487,21 @@ A practical way to think about prepend is that it’s good for “prefer this ci
 This is the classic enterprise ask. Outbound is “prefer circuit A, keep B as backup” (LOCAL_PREF), and inbound is “encourage the provider to send traffic to you via circuit A”.
 
 ```mermaid
+%%{init: {'theme':'neutral','flowchart':{'curve':'basis'},'themeVariables':{'fontFamily':'Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial'}}}%%
 flowchart LR
-  Internet[(Users / Internet)] --> P[Provider AS]
-  P -->|Link A| CE1[Your Edge]
-  P -->|Link B| CE2[Your Edge]
+  classDef enterprise fill:#E8F1FF,stroke:#2F6FED,stroke-width:1px,color:#0B1F44;
+  classDef provider fill:#FFF3E0,stroke:#F59E0B,stroke-width:1px,color:#3B2F00;
+  classDef edge fill:#F3E8FF,stroke:#8B5CF6,stroke-width:1px,color:#2E1065;
 
-  CE1 --> LAN[Your prefixes]
+  Internet[(Users / Internet)]:::provider --> P[Provider AS]:::provider
+  P -->|Link A| CE1[Your edge A]:::edge
+  P -->|Link B| CE2[Your edge B]:::edge
+
+  CE1 --> LAN[Your prefixes]:::enterprise
   CE2 --> LAN
 
-  %% Inbound: provider decides path towards you
-  %% Tools: communities (cleanest), MED (if honoured), AS_PATH prepend (portable)
+  %% Inbound: provider decides the path towards you.
+  %% Tools: communities (cleanest), MED (if honoured), AS_PATH prepend (portable).
 ```
 A pragmatic ordering is:
 
@@ -552,33 +572,38 @@ The assumption for the examples in this post is that you host your own routers i
 A common pattern is to use two CNFs for physical and geographic diversity, for example separate meet-me rooms, separate fibre paths, and separate power domains and blast radius.
 
 ```mermaid
-flowchart TB
+%%{init: {'theme':'neutral','flowchart':{'curve':'basis'},'themeVariables':{'fontFamily':'Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial'}}}%%
+flowchart LR
+  classDef enterprise fill:#E8F1FF,stroke:#2F6FED,stroke-width:1px,color:#0B1F44;
+  classDef cloud fill:#E7F8EF,stroke:#10B981,stroke-width:1px,color:#05361F;
+  classDef edge fill:#F3E8FF,stroke:#8B5CF6,stroke-width:1px,color:#2E1065;
+
+  subgraph Enterprise[Enterprise]
+    Core[Core / RR]:::enterprise
+  end
+
   subgraph CNF1[CNF 1]
-    E1[Edge Router]
+    E1[Edge router]:::edge
   end
 
   subgraph CNF2[CNF 2]
-    E2[Edge Router]
+    E2[Edge router]:::edge
   end
 
   subgraph Clouds[Cloud peers]
-    AZ[Azure ER Peer]
-    AWS[AWS DX Peer]
+    AZ[Azure ER peer]:::cloud
+    AWS[AWS DX peer]:::cloud
   end
 
-  subgraph Ent[Enterprise]
-    Core[Core / RR]
-  end
+  Core -- iBGP / internal --> E1
+  Core -- iBGP / internal --> E2
 
   E1 -- eBGP --> AZ
   E1 -- eBGP --> AWS
   E2 -- eBGP --> AZ
   E2 -- eBGP --> AWS
 
-  E1 -- iBGP / internal --> Core
-  E2 -- iBGP / internal --> Core
-
-  %% Two CNFs give physical diversity, BGP policy decides preference and failover
+  %% Two CNFs give physical diversity. BGP policy decides preference and failover.
 ```
 
 You then decide whether the design is active/active northbound (both CNFs have cloud peers up), or active/passive (one CNF is preferred, and the other is failover).

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -755,17 +755,21 @@ On the other hand, in some **private multi-cloud CNF** designs, you might *delib
 
 Max-prefix is your seatbelt.
 
-It limits how many routes you’re willing to accept from a neighbour.
-If you expected “a few hundred prefixes” and you suddenly receive “the full internet”, max-prefix can stop that mistake becoming a widespread outage.
+It limits how many routes you’re willing to accept from a neighbour. If you expected “a few hundred prefixes” and you suddenly receive “the full internet”, max-prefix can stop that mistake becoming a widespread outage.
 
-A pragmatic enterprise approach is:
-- set max-prefix on every eBGP peer
-- set the threshold based on what you *expect* (plus headroom)
-- decide the failure mode:
-  - warn-only (log) vs
-  - hard-teardown (drop the session)
+A pragmatic enterprise approach is to set max-prefix on every eBGP peer, to size the threshold based on what you *expect* (plus headroom), and to decide the failure mode ahead of time, for example warn-only logging versus hard-teardown.
 
-> If you’re peering with an upstream that can legitimately send you huge tables (e.g., full routes), max-prefix is still useful; you just size it appropriately.
+> Sidebar: max-prefix as a rite of passage
+>
+> BT have historically had a very low default prefix limit on some enterprise BGP peerings.
+>
+> At ASDA, it was almost a rite of passage that someone would, at least once in their time there, remove or loosen a prefix filter, hit the prefix limit, and watch the BGP session drop.
+>
+> The extra sting is that BT don’t necessarily auto-timeout and recover quickly. Even after you fix the policy, you may need to raise a priority support ticket to get the peering reset.
+>
+> The lesson is simple, and painfully memorable: max-prefix is there to save you, but your filters are what stop you needing the ticket in the first place.
+
+If you’re peering with an upstream that can legitimately send you huge tables (e.g., full routes), max-prefix is still useful; you just size it appropriately.
 
 ### Route refresh / soft reconfig basics
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -225,7 +225,47 @@ That’s why a lot of BGP guidance boils down to:
 
 ## 6) BGP path selection (the bits you actually use)
 
-(TODO: high-level decision flow — keep it practical and focus on attributes we’ll touch later)
+BGP path selection looks intimidating until you realise two things:
+1) most of the decision process only matters when you have multiple candidate routes to the *same* prefix, and
+2) in enterprise designs you tend to use a small handful of attributes deliberately.
+
+We’ll keep this vendor-neutral and focus on the knobs you’ll actually touch at a cloud/WAN edge.
+
+### The simplified mental model
+
+When a router has multiple routes to the same destination prefix, it picks a “best” path by comparing attributes in a consistent order.
+
+In practice, for enterprise connectivity, you can think in three buckets:
+
+- **Things you set internally to steer *your outbound*** (e.g., LOCAL_PREF)
+- **Things you can signal to a neighbour to *influence inbound*** (e.g., MED, AS_PATH)
+- **Tie-breakers** (where BGP picks something stable when your policy doesn’t decide)
+
+### The three attributes you’ll use constantly
+
+- **LOCAL_PREF**: your strongest tool for choosing the outbound exit *inside your AS*.
+- **AS_PATH**: one of the few levers that naturally propagates beyond your first-hop peer.
+- **MED**: a hint to a neighbour, with limits.
+
+> We’ll go deeper on how to use each of these in Sections 7 and 8.
+
+### Real-world scenarios we’ll map onto these knobs
+
+These come up constantly in enterprise cloud/WAN designs:
+
+1) **Single ASN, multiple upstream ASNs, and you want to override path selection**
+   - e.g., your preferred route has a longer AS_PATH, but you still want to send traffic that way.
+   - Typical solution: **LOCAL_PREF**.
+
+2) **Two links to the same provider and you want symmetric preference**
+   - Outbound: **LOCAL_PREF**.
+   - Inbound: **MED** (when honoured) or **AS_PATH prepending** (blunt but portable).
+
+3) **Two private ASNs (two edges) peered to a single remote ASN, and you want end-to-end path control**
+   - The tricky bit: LOCAL_PREF and MED don’t travel “downstream”.
+   - The portable lever: AS_PATH signals (and, where supported, community-based knobs).
+
+We’ll work through these explicitly as we go.
 
 ## 7) Influencing outbound traffic (enterprise reality)
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -710,6 +710,14 @@ That’s rarely desirable, and it can also become expensive fast.
 
 The fix is boring and effective: strict import filters (what you accept), and strict export filters (what you advertise).
 
+Import filtering is more than just prefix-lists. In real designs you will often also filter based on AS_PATH and communities. You might explicitly exclude routes with certain ASNs in the path, you might import only routes sourced from a specific ASN (to avoid your peer becoming an accidental transit), and you might use communities as the selection key, for example AWS regional indicators.
+
+> Sidebar: regional route filtering to keep control of latency
+>
+> At a large fintech I worked at we had ExpressRoute and Direct Connect in many regions. We deliberately imported only the cloud routes that were relevant to each region, because we wanted inter-region traffic to stay on our own low-latency network, not to wander across a hyperscaler backbone just because it was reachable.
+>
+> This is where communities become genuinely useful, not for “clever traffic engineering”, but as a clean mechanism to scope what you import.
+
 ### Example: dual-provider internet peering (don’t become transit)
 
 In this pattern you receive routes from two upstreams, but you only ever advertise your own prefixes, and optionally a default or a small set of aggregates you explicitly intend to originate.

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -794,12 +794,42 @@ If it doesn’t, you’ll end up doing some kind of clear/reset — just do it i
 
 ## 12) Cloud specifics (light touch)
 
+This post is intentionally vendor-neutral, but cloud connectivity has a few “cloud-shaped” differences that are worth keeping in mind.
+
 ### What’s different for DX/ER vs MPLS peering
-(TODO)
+
+Some practical differences you’ll feel:
+
+- **You’re peering to a cloud service, not a human-run PE router.**
+  - behaviours are documented, but you don’t get to ring the NOC and ask them to tweak a knob “just this once”.
+
+- **Route limits are real.**
+  - there are hard limits on prefixes and routes in some cloud constructs.
+  - this makes filtering/summarisation and intentional route design more important.
+
+- **Public peering options exist (and come with sharp edges).**
+  - DX public VIF / ER Microsoft peering can be great for predictable paths to public services.
+  - they’re also where you really don’t want to accidentally export something that turns you into transit.
+
+- **Availability patterns are “product-shaped”.**
+  - you’ll often have multiple BGP sessions per circuit, dual circuits, and region/site diversity patterns.
+  - the BGP knobs are the same; the constraints around them are not.
 
 ### Route Server (brief pointer)
-(TODO: link to existing posts)
+
+If you’re using managed route distribution services (like Azure Route Server), you’ll run into platform constraints that exist specifically to prevent certain transit patterns.
+
+I’ve written up one of the key behaviours and its design implications here:
+https://www.simonpainter.com/transit-route-prevention/
 
 ## Conclusion
 
-(TODO)
+BGP can look intimidating because the internet uses it, and the internet is huge.
+
+But enterprise cloud connectivity only needs a subset:
+- understand the eBGP vs iBGP boundary
+- know which attributes are useful in practice (LOCAL_PREF, AS_PATH, MED)
+- use communities when the provider documents them
+- and put safety rails around import/export so you don’t leak routes or accidentally become transit
+
+If you get those right, you’ll be able to design hybrid multi-cloud connectivity that behaves predictably — and when it doesn’t, you’ll know where to look.

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -1,5 +1,8 @@
 ---
 title: "BGP for Enterprise Cloud Connectivity"
+
+> **BGP** (Border Gateway Protocol): the routing protocol we use to exchange prefixes and policy between autonomous systems, and sometimes between large internal domains.
+
 authors: simonpainter
 tags:
   - networks
@@ -51,12 +54,20 @@ eBGP is what you run between your network and someone else’s.
 
 In enterprise cloud connectivity that usually means your router in a CNF peering with an **ExpressRoute** MSEE or **Direct Connect** router, your router peering with an ISP, or your router peering with a managed MPLS provider PE.
 
+> **MSEE** (Microsoft Enterprise Edge): Microsoft’s routers on the ExpressRoute edge that you peer with.
+
+> **PE** (Provider Edge): the provider’s edge router, facing customer circuits.
+
+> **CNF** (carrier neutral facility): a colocation site where you can cross-connect to multiple carriers, cloud on-ramps, and exchanges.
+
 The important enterprise mental model is: **eBGP is where the AS boundary is real**.
 Across that boundary you can exchange routes, and you can _influence_ the other side, but you don’t get to enforce how they do their internal routing.
 
 ### iBGP
 
 iBGP is what you run when you have multiple routers in **the same ASN** that need to share BGP-learned routes with each other.
+
+> **ASN** (Autonomous System Number): the numeric identifier for an autonomous system, used in BGP for policy and loop prevention.
 
 In the simplest cloud edge, you might not need iBGP at all (one router, one peering).
 As soon as you add redundancy, iBGP becomes the clean way to make your edge behave like a single logical system:
@@ -92,6 +103,8 @@ BGP is often taught as “pick one best path”, which is true for what it adver
 
 Most platforms can install multiple equal-cost BGP paths for the same prefix (multipath) and then forward over them using ECMP. Whether paths are considered “equal enough” depends on the platform and config, but the important point is that multipath is an explicit design choice.
 
+> **ECMP** (equal-cost multipath): using multiple next-hops for the same prefix when they’re considered equally good.
+
 This matters in cloud connectivity because active/active circuit pairs often rely on it. ExpressRoute in particular is commonly delivered as redundant circuit pairs, and many designs expect to use both links in steady state. Without multipath, you can easily end up with “one link hot, one link cold”, even though you paid for both.
 
 If you need symmetric flows through stateful appliances, you might still choose active/passive, but if you are aiming for active/active, make sure you understand how your platform handles eBGP multipath, iBGP multipath, and the tie-breaks that decide which paths qualify.
@@ -108,11 +121,15 @@ That’s fine, but it can leave you with some slightly warped assumptions, becau
 
 Plenty of enterprises buy **managed CE routers**. In that model the provider owns the config, you may only see a handoff (LAN interface or VLAN), and you might never touch BGP at all.
 
+> **CE** (Customer Edge): your router at the edge of the provider network.
+
 Mechanically, BGP is still often involved somewhere, but it’s just **not your problem** until the day you add cloud connectivity, and suddenly it is.
 
 ### Common MPLS patterns (abstract mechanics)
 
 There are a few common ways MPLS WAN providers present routing. The exact implementation varies (VRFs, MP-BGP in the core, route targets, etc.), but the _customer-visible_ behaviours are pretty consistent.
+
+> **MP-BGP** (Multiprotocol BGP): BGP extensions for carrying multiple address families (like IPv4 and IPv6).
 
 ### Pattern A: PE/CE eBGP (provider AS visible)
 
@@ -204,7 +221,11 @@ That transport could be an MPLS or SD-WAN underlay, ExpressRoute or Direct Conne
 :::note BGP inside AWS constructs (it’s not just a hybrid edge protocol)
 BGP is no longer only about Direct Connect at the edge. AWS now has constructs where BGP drives changes inside the VPC routing domain.
 
+> **VPC** (Virtual Private Cloud): AWS’s private IP network construct, roughly analogous to a virtual network.
+
 A good example is Amazon VPC Route Server, which can use BGP to influence route tables (including IGW route tables) for patterns like floating IP failover, or steering traffic through active/standby inspection appliances.
+
+> **IGW** (Internet Gateway): the AWS VPC component that provides internet connectivity for public subnets.
 
 Useful starting point: [Dynamic Routing Using Amazon VPC Route Server](https://aws.amazon.com/blogs/networking-and-content-delivery/dynamic-routing-using-amazon-vpc-route-server/)
 :::
@@ -212,6 +233,8 @@ Useful starting point: [Dynamic Routing Using Amazon VPC Route Server](https://a
 ### What’s actually peering with what?
 
 In the model we’re using for this post, your routers sit in one (or two) CNFs, you have L2 to each provider peer, and you run eBGP to Azure (ExpressRoute private peering), AWS (Direct Connect private VIF), and optionally your WAN provider(s) if you’re also aggregating MPLS or SD-WAN there.
+
+> **VIF** (virtual interface): an AWS Direct Connect construct that represents a BGP-enabled L3 interface over a physical connection.
 
 ```mermaid
 %%{init: {'theme':'neutral','flowchart':{'curve':'basis'},'themeVariables':{'fontFamily':'Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial'}}}%%
@@ -255,6 +278,8 @@ Microsoft Learn content about ExpressRoute often talks about “peerings” and 
 Each peering (Private peering, and Microsoft peering) is delivered via a pair of independent eBGP sessions. If you exceed prefix limits, the default behaviour is for the BGP session to be terminated, which is a hard failure mode and a good reason to monitor prefix counts.
 
 Microsoft-side BGP timers are fixed (keepalive and hold), so fast failover is normally achieved with BFD, which is enabled by default on Microsoft’s side, but must be configured on your CPE.
+
+> **BFD** (Bidirectional Forwarding Detection): a fast failure-detection mechanism often used to speed up BGP convergence.
 
 Filtering is primarily your responsibility on the on-prem edge. Azure UDRs are static and not part of BGP advertisement. On Microsoft peering specifically, “no routes” is often explained by a missing route filter.
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -466,6 +466,9 @@ This post includes Mermaid diagrams for the key architectural patterns. If I’v
 - Add an operational section or sidebar on **proving resiliency**, including AWS **Direct Connect failover testing** and the idea of regular game-days.
 - Add an optional routing security sidebar: AWS’s posture on **RPKI/ROV** as context, and what that implies for enterprise expectations and internal hygiene.
 
+- Add a short sidebar on **AWS Route Server vs Azure Route Server**, to head off naming confusion and emphasise the transitive versus non-transitive difference (and why this matters for appliance failover and routing design): https://www.simonpainter.com/aws-route-server/
+- Optionally add a callout that AWS Route Server is primarily active/passive NVA failover orchestration in a single VPC, while Azure Route Server is closer to “BGP as a Service”, and point readers to the post above for the deeper comparison.
+
 ## Influencing inbound traffic (enterprise reality)
 
 Inbound is where BGP stops feeling like “routing” and starts feeling like diplomacy.

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -483,9 +483,7 @@ protocols {
 
 A few practical notes: in real configs you’ll almost always include explicit route filters (prefix-lists) alongside these policies. If you want active/active, LOCAL_PREF can still be used; you just set them equal, and rely on other mechanisms (or ECMP capability) to load-share.
 
-## Diagrams
-
-This post includes Mermaid diagrams for the key architectural patterns. If I’ve missed an example you care about, it’s usually a sign I should diagram it out.
+Outbound is the easy part. Inbound is where things get interesting.
 
 ## Influencing inbound traffic (enterprise reality)
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -583,7 +583,102 @@ Assumption for the examples in this post:
 ## 11) Safety rails (the section that saves outages)
 
 ### Prefix-lists / route filtering
-(TODO)
+
+If you take only one operational lesson from BGP, take this:
+
+- **BGP doesn’t make you a transit network. Your policies do.**
+
+The most common way enterprises accidentally become transit is simple:
+- you learn routes from provider A,
+- you learn routes from provider B,
+- and you mistakenly export A’s routes to B (and/or vice versa).
+
+That’s rarely desirable.
+It can also become expensive fast.
+
+The fix is boring and effective:
+- strict **import filters** (what you accept)
+- strict **export filters** (what you advertise)
+
+#### Example: dual-provider internet peering (don’t become transit)
+
+In this pattern you receive routes from two upstreams, but you only ever advertise:
+- your own prefixes, and
+- (optionally) a default or a small set of aggregates you explicitly intend to originate.
+
+**IOS-XE (illustrative)**
+```ios
+ip prefix-list MY-PREFIXES seq 10 permit 203.0.113.0/24
+!
+route-map EXPORT-ONLY-MY-PREFIXES permit 10
+ match ip address prefix-list MY-PREFIXES
+!
+route-map EXPORT-ONLY-MY-PREFIXES deny 100
+!
+router bgp 65001
+ neighbor 198.51.100.1 remote-as 64510
+ neighbor 198.51.100.2 remote-as 64520
+!
+ neighbor 198.51.100.1 route-map EXPORT-ONLY-MY-PREFIXES out
+ neighbor 198.51.100.2 route-map EXPORT-ONLY-MY-PREFIXES out
+```
+
+**JunOS (illustrative)**
+```junos
+policy-options {
+  prefix-list MY-PREFIXES {
+    203.0.113.0/24;
+  }
+  policy-statement EXPORT-ONLY-MY-PREFIXES {
+    term ALLOW-MINE {
+      from prefix-list MY-PREFIXES;
+      then accept;
+    }
+    term DENY-REST {
+      then reject;
+    }
+  }
+}
+protocols {
+  bgp {
+    group ISP-A {
+      type external;
+      peer-as 64510;
+      export EXPORT-ONLY-MY-PREFIXES;
+      neighbor 198.51.100.1;
+    }
+    group ISP-B {
+      type external;
+      peer-as 64520;
+      export EXPORT-ONLY-MY-PREFIXES;
+      neighbor 198.51.100.2;
+    }
+  }
+}
+```
+
+The same principle applies to **public cloud public-peering** models:
+- **DX public VIF** and **ER Microsoft peering** are *not* a place you want to accidentally become transit.
+- If you’re receiving public prefixes from the provider, be deliberate about what you export back.
+
+On the other hand, in some **private multi-cloud CNF** designs, you might *deliberately* act as a transit:
+- e.g., allow private traffic from Cloud A to reach Cloud B via your exchange routers.
+- That’s a valid architecture — but only if you do it intentionally and keep it isolated from public-routing domains.
+
+> Sidebar: RPSL (Routing Policy Specification Language)
+>
+> In the public internet, routing policy is often described using RPSL objects (route/route6, aut-num, etc.), which are then used to build prefix filters.
+> It’s one of the reasons “who should accept what from whom” can be automated at scale.
+>
+> If you’ve never bumped into it before: https://en.wikipedia.org/wiki/Routing_Policy_Specification_Language
+
+> Sidebar: how Azure prevents some transit scenarios
+>
+> Microsoft actively prevents certain transit-routing behaviours in the backbone (for good reasons).
+> If you’re using Route Server + ExpressRoute in multi-hub designs, this can show up as “routes learned in one place aren’t propagated to another” when a shared circuit is involved.
+>
+> I wrote up the behaviour and the design implications here:
+> https://www.simonpainter.com/transit-route-prevention/
 
 ### Max-prefix
 (TODO)

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -82,24 +82,71 @@ If you understand the eBGP/iBGP boundary, the rest of BGP becomes much less myst
 
 ## 3) Where enterprise engineers have seen BGP before: MPLS WAN patterns
 
+For a lot of enterprise folks, “BGP experience” starts and ends with *an MPLS circuit*.
+That’s fine — but it can leave you with some slightly warped assumptions, because MPLS providers can make BGP look like anything from “a normal eBGP peer” to “a magic ethernet cable between sites”.
+
 ### Managed CEs (you might never have seen the BGP config)
-(TODO)
 
-### Common MPLS patterns
+Plenty of enterprises buy **managed CE routers**. In that model:
+- the provider owns the config,
+- you may only see a handoff (LAN interface / VLAN),
+- and you might never touch BGP at all.
 
-#### PE/CE eBGP (provider AS visible)
-(TODO)
+Mechanically, BGP is still often involved somewhere — it’s just **not your problem** until the day you add cloud connectivity and suddenly it is.
 
-#### CE–CE style eBGP (provider AS not visible)
-(TODO: explain the concept and what it implies; provider carries/redistributes customer routes internally)
+### Common MPLS patterns (abstract mechanics)
+
+There are a few common ways MPLS WAN providers present routing. The exact implementation varies (VRFs, MP-BGP in the core, route targets, etc.), but the *customer-visible* behaviours are pretty consistent.
+
+#### Pattern A: PE/CE eBGP (provider AS visible)
+
+This is the “textbook” model.
+
+- Your CE runs **eBGP to the provider PE**.
+- The provider PE is in **the provider’s ASN**, so you see the provider AS in the AS_PATH (or at least you *can*).
+- Your routes are imported into the provider’s MPLS VPN routing domain and distributed to other sites.
+
+Why this matters for the cloud journey: this is the closest mental model to DX/ER peering.
+
+#### Pattern B: CE–CE peering over MPLS (customer edges peer with each other)
+
+You called this out explicitly, and yes — I’ve seen this in the wild too.
+
+In this design, the provider network is treated as **a transport underlay**, and the **customer edge routers form BGP adjacencies with each other** (directly or via some kind of rendezvous).
+
+What it looks like from the customer’s point of view:
+- Site A CE has BGP neighbours that are *other customer CEs*.
+- The provider ASN may not appear in the AS_PATH (because the provider isn’t acting as a BGP hop in your control plane).
+
+What has to be true for it to work:
+- The provider must provide **IP reachability between CEs** (it’s effectively giving you a routed point-to-point / any-to-any service), and
+- the provider is **not** doing your inter-site route exchange for you — *your BGP* is.
+
+This pattern is conceptually closer to “running your own WAN overlay” than to classic managed MPLS L3VPN routing.
 
 ### ASNs in MPLS enterprise designs
 
 #### Per-site ASNs
-(TODO)
+
+A very common enterprise pattern is:
+- each site has its own private ASN, or
+- sites are grouped into a small pool of private ASNs.
+
+It’s convenient because it keeps the eBGP loop-prevention behaviour simple: every site is “a different AS”, so re-advertisement between sites doesn’t trip over “I see myself in the AS_PATH”.
 
 #### Single ASN across all sites (and why private-AS stripping matters)
-(TODO: explain why a route from site A reaches site B, gets dropped if B sees its own AS in AS_PATH)
+
+It’s equally valid to run **the same ASN at every site**.
+
+But you need to understand one hard rule:
+
+- If site A advertises a prefix to the WAN, and that route is later presented to site B *with the same ASN still in the AS_PATH*, then **site B will drop it**.
+
+That’s not a bug — that’s BGP doing loop prevention: *“I won’t accept a route that already contains my ASN.”*
+
+So if you run “single ASN everywhere” using a private ASN, the provider typically has to do **private-AS removal/stripping** between sites.
+
+This exact idea shows up again in cloud connectivity designs when you’re deciding whether to use one ASN globally, or split ASNs per edge/site.
 
 ## 4) Peering relationships in enterprise cloud connectivity
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -459,6 +459,13 @@ A few practical notes: in real configs you’ll almost always include explicit r
 
 This post includes Mermaid diagrams for the key architectural patterns. If I’ve missed an example you care about, it’s usually a sign I should diagram it out.
 
+## TODO (new topics to incorporate)
+
+- Consider a short section or sidebar on **BGP inside AWS constructs**, for example Amazon **VPC Route Server** driving VPC route table and IGW route table changes for dynamic routing patterns (floating IP failover, and firewall insertion).
+- Consider a short section on **AWS Cloud WAN Connect** in an enterprise WAN framing, including the MP-BGP/IPv6 nuance, ECMP, and the “GRE versus tunnel-less” design choice.
+- Add an operational section or sidebar on **proving resiliency**, including AWS **Direct Connect failover testing** and the idea of regular game-days.
+- Add an optional routing security sidebar: AWS’s posture on **RPKI/ROV** as context, and what that implies for enterprise expectations and internal hygiene.
+
 ## Influencing inbound traffic (enterprise reality)
 
 Inbound is where BGP stops feeling like “routing” and starts feeling like diplomacy.

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -1,8 +1,6 @@
 ---
 title: "BGP for Enterprise Cloud Connectivity"
 
-> **BGP** (Border Gateway Protocol): the routing protocol we use to exchange prefixes and policy between autonomous systems, and sometimes between large internal domains.
-
 authors: simonpainter
 tags:
   - networks
@@ -55,9 +53,9 @@ eBGP is what you run between your network and someone else’s.
 In enterprise cloud connectivity that usually means your router in a CNF peering with an **ExpressRoute** MSEE or **Direct Connect** router, your router peering with an ISP, or your router peering with a managed MPLS provider PE.
 
 > **MSEE** (Microsoft Enterprise Edge): Microsoft’s routers on the ExpressRoute edge that you peer with.
-
-> **PE** (Provider Edge): the provider’s edge router, facing customer circuits.
-
+>
+>**PE** (Provider Edge): the provider’s edge router, facing customer circuits.
+>
 > **CNF** (carrier neutral facility): a colocation site where you can cross-connect to multiple carriers, cloud on-ramps, and exchanges.
 
 The important enterprise mental model is: **eBGP is where the AS boundary is real**.

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -21,9 +21,23 @@ And it’s not fair to assume that every enterprise network engineer has spent y
 
 So this post is an explainer of the key BGP concepts that an enterprise network engineer needs to feel comfortable designing and operating **hybrid, multi-cloud connectivity**, where BGP plays its vital role.
 
-<!--truncate-->
+<!--truncate-->## On this page
 
-## What BGP is (in one page)
+- [What BGP is](#what-bgp-is)
+- [eBGP and iBGP at the cloud edge](#ebgp-and-ibgp-at-the-cloud-edge)
+- [BGP in MPLS WANs](#bgp-in-mpls-wans)
+- [How cloud peerings fit together](#how-cloud-peerings-fit-together)
+- [What to advertise (and what not to)](#what-to-advertise-and-what-not-to)
+- [How BGP picks a path](#how-bgp-picks-a-path)
+- [Steering outbound traffic](#steering-outbound-traffic)
+- [Influencing inbound traffic](#influencing-inbound-traffic)
+- [BGP communities](#bgp-communities)
+- [Cloud exchange (CNF) patterns](#cloud-exchange-cnf-patterns)
+- [Safety rails](#safety-rails)
+- [Cloud-specific gotchas](#cloud-specific-gotchas)
+- [Wrapping up](#wrapping-up)
+
+## What BGP is
 
 BGP is a _path-vector_ routing protocol. You don’t “discover the best path” by calculating the shortest path through a topology (like you do with link-state protocols). Instead, you **learn candidate paths** via advertisements, then you **select** between them using a predictable decision process.
 
@@ -36,7 +50,7 @@ BGP is also **policy-first**. It’s designed for environments where “best” 
 > If you want the deeper reasoning: I wrote about OSPF scaling constraints and why BGP scales differently here:
 > https://www.simonpainter.com/dijkstra-ospf/
 
-## eBGP vs iBGP (what matters at the cloud edge)
+## eBGP and iBGP at the cloud edge
 
 There are two flavours of BGP in day-to-day designs:
 
@@ -100,7 +114,7 @@ Because **your operational knobs behave differently depending on where you are**
 
 If you understand the eBGP/iBGP boundary, the rest of BGP becomes much less mysterious.
 
-## Where enterprise engineers have seen BGP before: MPLS WAN patterns
+## BGP in MPLS WANs
 
 For a lot of enterprise folks, “BGP experience” starts and ends with _an MPLS circuit_.
 That’s fine, but it can leave you with some slightly warped assumptions, because MPLS providers can make BGP look like anything from “a normal eBGP peer” to “a magic ethernet cable between sites”.
@@ -222,7 +236,7 @@ So if you run “single ASN everywhere” using a private ASN, the provider typi
 
 This exact idea shows up again in cloud connectivity designs when you’re deciding whether to use one ASN globally, or split ASNs per edge/site.
 
-## Peering relationships in enterprise cloud connectivity
+## How cloud peerings fit together
 
 If you strip away the product names, enterprise cloud connectivity is mostly just this: you have internal prefixes on one side (data centres, campus, and branch sites), you have cloud prefixes on the other (VNets or VPCs, and whatever services sit behind them), and you use BGP to exchange routes between the two over some private transport.
 
@@ -300,7 +314,7 @@ Anything that crosses an AS boundary is, by definition, a negotiation. You can u
 
 That’s why a lot of BGP guidance boils down to keeping your intent simple, applying safety rails, and not relying on a single knob (especially for inbound) unless you’ve validated the provider behaviour.
 
-## Route advertisement basics (what you advertise and why)
+## What to advertise (and what not to)
 
 This is where most real-world BGP outages come from.
 Not because someone misunderstood the BGP decision process, but because someone advertised (or accepted) more routes than they intended.
@@ -340,7 +354,7 @@ Default routes are a great tool when used intentionally. In small branch designs
 
 If you use defaults, treat them like any other route. Filter them explicitly, set their preference intentionally, and test the failure mode (what happens when the preferred exit disappears?).
 
-## BGP path selection (the bits you actually use)
+## How BGP picks a path
 
 BGP path selection looks intimidating until you realise two things:
 
@@ -373,7 +387,7 @@ In practice, for enterprise connectivity, you can think in three buckets: things
 
 The three attributes you’ll use constantly are LOCAL_PREF, which is your strongest tool for choosing the outbound exit inside your AS, AS_PATH, which is one of the few levers that naturally propagates beyond your first-hop peer, and MED, which is a hint to a neighbour, with limits.
 
-We’ll go deeper on how to use each of these in Sections 7 and 8.
+I’ll go deeper on how to use each of these in [Steering outbound traffic](#steering-outbound-traffic) and [Influencing inbound traffic](#influencing-inbound-traffic).
 
 ### Real-world scenarios we’ll map onto these knobs
 
@@ -395,7 +409,7 @@ These come up constantly in enterprise cloud/WAN designs:
 
 We’ll work through these explicitly as we go.
 
-## Influencing outbound traffic (enterprise reality)
+## Steering outbound traffic
 
 Outbound is the part you _actually_ control.
 If you’re deciding which circuit you want to use to _leave your network_, BGP gives you a few options, but in enterprise designs **LOCAL_PREF** is the one you’ll use constantly.
@@ -485,7 +499,7 @@ A few practical notes: in real configs you’ll almost always include explicit r
 
 Outbound is the easy part. Inbound is where things get interesting.
 
-## Influencing inbound traffic (enterprise reality)
+## Influencing inbound traffic
 
 Inbound is where BGP stops feeling like “routing” and starts feeling like diplomacy.
 
@@ -575,7 +589,7 @@ They’re often the cleanest way to do inbound steering because the provider can
 I’ve written a more detailed comparison of how Azure and AWS use communities here:
 https://www.simonpainter.com/community-comparison/
 
-## Communities (the provider-supported knobs)
+## BGP communities
 
 BGP communities are just tags.
 That sounds underwhelming, but it’s exactly why they’re powerful.
@@ -611,7 +625,7 @@ https://www.simonpainter.com/community-comparison/
 
 Start with the provider’s documentation for the specific connection type (DX public or private VIF, and ER private or Microsoft peering). Implement communities in code and policy with the same discipline as firewall rules, including version control, review, explicit intent, and testing. Prefer communities over “clever” AS_PATH games when the provider supports the behaviour you need.
 
-## Cloud exchange / carrier neutral facility (CNF) patterns
+## Cloud exchange (CNF) patterns
 
 A cloud exchange is typically a **carrier neutral facility (CNF)** where you can aggregate cloud provider connectivity (ExpressRoute and Direct Connect), and WAN connectivity (MPLS and SD-WAN).
 
@@ -723,7 +737,7 @@ flowchart LR
   %% AS_PATH and provider-supported communities are the tools that can travel beyond the edge.
 ```
 
-## Safety rails (the section that saves outages)
+## Safety rails
 
 ### Prefix-lists / route filtering
 
@@ -894,7 +908,7 @@ The exact commands differ (IOS-XE versus JunOS), but the operational goal is the
 If your platform supports route refresh, use it.
 If it doesn’t, you’ll end up doing some kind of clear/reset; just do it intentionally, and during a safe window.
 
-## Cloud specifics (light touch)
+## Cloud-specific gotchas
 
 This post is intentionally vendor-neutral, but cloud connectivity has a few “cloud-shaped” differences that are worth keeping in mind.
 
@@ -943,7 +957,7 @@ https://www.simonpainter.com/transit-route-prevention/
 >
 > If you want the deeper comparison (and the philosophy behind the difference), I wrote it up here: https://www.simonpainter.com/aws-route-server/
 
-## Conclusion
+## Wrapping up
 
 BGP can look intimidating because the internet uses it, and the internet is huge.
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -473,26 +473,10 @@ This post includes Mermaid diagrams for the key architectural patterns. If I’v
 
 ## TODO (new topics to incorporate)
 
-- Consider a short section or sidebar on **BGP inside AWS constructs**, for example Amazon **VPC Route Server** driving VPC route table and IGW route table changes for dynamic routing patterns (floating IP failover, and firewall insertion).
-- Consider a short section on **AWS Cloud WAN Connect** in an enterprise WAN framing, including the MP-BGP/IPv6 nuance, ECMP, and the “GRE versus tunnel-less” design choice.
+- Add a short section or sidebar on **BGP inside AWS constructs**, for example Amazon **VPC Route Server** driving VPC route table and IGW route table changes for dynamic routing patterns (floating IP failover, and firewall insertion).
+- Add a short section on **AWS Cloud WAN Connect** in an enterprise WAN framing, including the MP-BGP/IPv6 nuance, ECMP, and the “GRE versus tunnel-less” design choice.
 - Add an operational section or sidebar on **proving resiliency**, including AWS **Direct Connect failover testing** and the idea of regular game-days.
 - Add an optional routing security sidebar: AWS’s posture on **RPKI/ROV** as context, and what that implies for enterprise expectations and internal hygiene.
-
-- Add a short sidebar on **AWS Route Server vs Azure Route Server**, to head off naming confusion and emphasise the transitive versus non-transitive difference (and why this matters for appliance failover and routing design): https://www.simonpainter.com/aws-route-server/
-- Optionally add a callout that AWS Route Server is primarily active/passive NVA failover orchestration in a single VPC, while Azure Route Server is closer to “BGP as a Service”, and point readers to the post above for the deeper comparison.
-
-- Add an **ExpressRoute BGP essentials** callout that makes the BGP behaviour explicit (because the Microsoft Learn module underplays it), covering:
-  - each ExpressRoute peering is delivered via **a pair of independent eBGP sessions** (redundant);
-  - **prefix limit exceed** behavior (session termination) and why monitoring matters;
-  - fixed Microsoft-side **BGP timers** (keepalive/hold) and the recommendation to use **BFD** for faster failover;
-  - the boundary that route filtering is primarily an **on-prem edge** responsibility, and Azure UDRs are not dynamic/BGP;
-  - Microsoft peering specifics: no routes until a **route filter** is attached.
-
-Reference docs to cite:
-- https://learn.microsoft.com/en-us/azure/expressroute/expressroute-circuit-peerings
-- https://learn.microsoft.com/en-us/azure/expressroute/expressroute-faqs
-- https://learn.microsoft.com/en-us/azure/expressroute/design-architecture-for-resiliency
-- https://learn.microsoft.com/en-us/azure/troubleshoot/azure/expressroute/expressroute-troubleshooting-network-performance
 
 ## Influencing inbound traffic (enterprise reality)
 
@@ -848,6 +832,14 @@ On the other hand, in some **private multi-cloud CNF** designs, you might *delib
 > It’s one of the reasons “who should accept what from whom” can be automated at scale.
 >
 > If you’ve never bumped into it before: https://en.wikipedia.org/wiki/Routing_Policy_Specification_Language
+>
+> Sidebar: a quick note on RPKI and route validation
+>
+> RPKI is the mechanism that lets prefix holders publish cryptographic Route Origin Authorisations (ROAs), and lets networks validate whether a route announcement is likely to be legitimate.
+>
+> Even if your enterprise BGP is mostly “private”, the upstreams you depend on operate in the public routing system, and the industry is increasingly treating RPKI-invalid routes as something to drop, not just something to log.
+>
+> AWS has a good high-level write-up of what they’re doing here, which is useful context: https://aws.amazon.com/blogs/networking-and-content-delivery/how-aws-is-helping-to-secure-internet-routing/
 
 > Sidebar: how Azure prevents some transit scenarios
 >
@@ -908,6 +900,16 @@ If you’re using managed route distribution services (like Azure Route Server),
 
 I’ve written up one of the key behaviours and its design implications here:
 https://www.simonpainter.com/transit-route-prevention/
+
+> Sidebar: AWS Route Server versus Azure Route Server
+>
+> AWS Route Server and Azure Route Server sound like the same thing, but they aren’t.
+>
+> Azure Route Server is closer to “BGP as a Service”, it peers using standard BGP and can support transitive routing patterns that feel familiar to enterprise network engineers.
+>
+> AWS Route Server is a more specialised tool, it is primarily about orchestrating active/passive appliance failover by manipulating specific route tables, and it is deliberately non-transitive.
+>
+> If you want the deeper comparison (and the philosophy behind the difference), I wrote it up here: https://www.simonpainter.com/aws-route-server/
 
 ## Conclusion
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -861,11 +861,13 @@ It’s one of the reasons “who should accept what from whom” can be automate
 If you’ve never bumped into it before: [Routing Policy Specification Language](https://en.wikipedia.org/wiki/Routing_Policy_Specification_Language)
 :::
 
+:::note RPKI and route origin validation
 RPKI is the mechanism that lets prefix holders publish cryptographic Route Origin Authorisations (ROAs), and lets networks validate whether a route announcement is likely to be legitimate.
 
 Even if your enterprise BGP is mostly “private”, the upstreams you depend on operate in the public routing system, and the industry is increasingly treating RPKI-invalid routes as something to drop, not just something to log.
 
 AWS has a good high-level write-up of what they’re doing here, which is useful context: [How AWS is helping to secure internet routing](https://aws.amazon.com/blogs/networking-and-content-delivery/how-aws-is-helping-to-secure-internet-routing/)
+:::
 
 :::note how Azure prevents some transit scenarios
 Microsoft actively prevents certain transit-routing behaviours in the backbone (for good reasons).

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -44,7 +44,7 @@ There are two flavours of BGP in day-to-day designs:
 - **iBGP** (internal BGP): between routers _inside_ the same autonomous system.
 
 If you’ve only ever "touched BGP" at an MPLS edge, you’ve almost certainly only seen **eBGP**.
-Cloud connectivity tends to drag iBGP into the conversation because you suddenly have **multiple edges** (two routers, two sites, two CNFs, two clouds) and you need consistent policy and predictable failover.
+Cloud connectivity tends to drag iBGP into the conversation because you suddenly have **multiple edges** (two routers, two sites, two CNFs (carrier neutral facilities), two clouds) and you need consistent policy and predictable failover.
 
 ### eBGP
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -327,18 +327,87 @@ We’ll work through these explicitly as we go.
 
 ## 7) Influencing outbound traffic (enterprise reality)
 
+Outbound is the part you *actually* control.
+If you’re deciding which circuit you want to use to *leave your network*, BGP gives you a few options — but in enterprise designs **LOCAL_PREF** is the one you’ll use constantly.
+
 ### LOCAL_PREF (the clean internal lever)
-(TODO)
 
-### IOS-XE example (LOCAL_PREF outbound preference)
+LOCAL_PREF is an attribute you set **inside your AS** to express preference for one exit over another.
+Higher LOCAL_PREF wins.
+
+It’s popular for three reasons:
+- it’s deterministic
+- it’s simple to reason about
+- it doesn’t require you to play games with AS_PATH length
+
+> Sidebar: ECMP vs active/passive is often dictated by security appliances.
+>
+> ECMP (active/active) has real value, but plenty of real networks have stateful firewalls or NAT devices that **aren’t clustered**.
+> Those designs often require **symmetric paths** (same in and out) to avoid breaking sessions.
+> In that world, active/passive circuits aren’t a failure of imagination — they’re a pragmatic requirement.
+
+### Pattern: prefer exit A, keep exit B as backup
+
+This is the bread-and-butter enterprise requirement.
+
+- You learn the same (or overlapping) routes from two upstreams / two circuits.
+- You want all outbound traffic to prefer circuit A.
+- If A fails, you want traffic to move to B.
+
+Mechanically, you do this by:
+- matching the routes you learn from neighbour A and setting a higher LOCAL_PREF,
+- leaving neighbour B at a lower LOCAL_PREF.
+
+### IOS-XE example (set LOCAL_PREF higher for routes learned from preferred peer)
+
 ```ios
-! TODO
+router bgp 65001
+ neighbor 192.0.2.1 remote-as 64512
+ neighbor 192.0.2.2 remote-as 64512
+!
+route-map PREFER-PEER-A-IN permit 10
+ set local-preference 200
+!
+route-map PREFER-PEER-B-IN permit 10
+ set local-preference 100
+!
+router bgp 65001
+ neighbor 192.0.2.1 route-map PREFER-PEER-A-IN in
+ neighbor 192.0.2.2 route-map PREFER-PEER-B-IN in
 ```
 
-### JunOS example (LOCAL_PREF outbound preference)
+### JunOS example (set LOCAL_PREF higher for routes learned from preferred peer)
+
 ```junos
-# TODO
+policy-options {
+  policy-statement PREFER-PEER-A-IN {
+    then local-preference 200;
+  }
+  policy-statement PREFER-PEER-B-IN {
+    then local-preference 100;
+  }
+}
+protocols {
+  bgp {
+    group PEER-A {
+      type external;
+      peer-as 64512;
+      import PREFER-PEER-A-IN;
+      neighbor 192.0.2.1;
+    }
+    group PEER-B {
+      type external;
+      peer-as 64512;
+      import PREFER-PEER-B-IN;
+      neighbor 192.0.2.2;
+    }
+  }
+}
 ```
+
+A few practical notes:
+- In real configs you’ll almost always include **explicit route filters** (prefix-lists) alongside these policies.
+- If you want active/active, LOCAL_PREF can still be used — you just set them equal and rely on other mechanisms (or ECMP capability) to load-share.
 
 ## 8) Influencing inbound traffic (enterprise reality)
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -22,7 +22,7 @@ And it’s not fair to assume that every enterprise network engineer has spent y
 
 So this post is an explainer of the key BGP concepts that an enterprise network engineer needs to feel comfortable designing and operating **hybrid, multi-cloud connectivity**, where BGP plays its vital role.
 
-<!--truncate-->
+<!-- truncate -->
 
 ## What BGP is
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -94,16 +94,16 @@ On Cisco platforms, the default administrative distances reflect a common design
 The rationale is pragmatic. If you’ve already learned the route from the IGP, it’s often “closer” and more efficient to follow that IGP path than to follow an iBGP hop-count that might simply be reflecting policy, or topology you don’t want to traverse.
 
 The punchline is that if you redistribute between protocols, or if you run BGP deep in the network, you should understand how administrative distance interacts with BGP, and consider whether you need to tune it for your design.
+:::
 
-Sidebar: iBGP and eBGP multipath (and why you suddenly care in cloud)
+:::info iBGP and eBGP multipath (and why you suddenly care in cloud)
+BGP is often taught as "pick one best path", which is true for what it advertises, but not always true for what it forwards.
 
-BGP is often taught as “pick one best path”, which is true for what it advertises, but not always true for what it forwards.
+Most platforms can install multiple equal-cost BGP paths for the same prefix (multipath) and then forward over them using ECMP. Whether paths are considered "equal enough" depends on the platform and config, but the important point is that multipath is an explicit design choice.
 
-Most platforms can install multiple equal-cost BGP paths for the same prefix (multipath) and then forward over them using ECMP. Whether paths are considered “equal enough” depends on the platform and config, but the important point is that multipath is an explicit design choice.
+> **ECMP** (equal-cost multipath): using multiple next-hops for the same prefix when they're considered equally good.
 
-> **ECMP** (equal-cost multipath): using multiple next-hops for the same prefix when they’re considered equally good.
-
-This matters in cloud connectivity because active/active circuit pairs often rely on it. ExpressRoute in particular is commonly delivered as redundant circuit pairs, and many designs expect to use both links in steady state. Without multipath, you can easily end up with “one link hot, one link cold”, even though you paid for both.
+This matters in cloud connectivity because active/active circuit pairs often rely on it. ExpressRoute in particular is commonly delivered as redundant circuit pairs, and many designs expect to use both links in steady state. Without multipath, you can easily end up with "one link hot, one link cold", even though you paid for both.
 
 If you need symmetric flows through stateful appliances, you might still choose active/passive, but if you are aiming for active/active, make sure you understand how your platform handles eBGP multipath, iBGP multipath, and the tie-breaks that decide which paths qualify.
 :::

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -21,21 +21,7 @@ And it’s not fair to assume that every enterprise network engineer has spent y
 
 So this post is an explainer of the key BGP concepts that an enterprise network engineer needs to feel comfortable designing and operating **hybrid, multi-cloud connectivity**, where BGP plays its vital role.
 
-<!--truncate-->## On this page
-
-- [What BGP is](#what-bgp-is)
-- [eBGP and iBGP at the cloud edge](#ebgp-and-ibgp-at-the-cloud-edge)
-- [BGP in MPLS WANs](#bgp-in-mpls-wans)
-- [How cloud peerings fit together](#how-cloud-peerings-fit-together)
-- [What to advertise (and what not to)](#what-to-advertise-and-what-not-to)
-- [How BGP picks a path](#how-bgp-picks-a-path)
-- [Steering outbound traffic](#steering-outbound-traffic)
-- [Influencing inbound traffic](#influencing-inbound-traffic)
-- [BGP communities](#bgp-communities)
-- [Cloud exchange (CNF) patterns](#cloud-exchange-cnf-patterns)
-- [Safety rails](#safety-rails)
-- [Cloud-specific gotchas](#cloud-specific-gotchas)
-- [Wrapping up](#wrapping-up)
+<!--truncate-->
 
 ## What BGP is
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -223,6 +223,18 @@ When a router has multiple routes to the same destination prefix, it picks a “
 
 In practice, for enterprise connectivity, you can think in three buckets: things you set internally to steer your outbound (for example, LOCAL_PREF), things you can signal to a neighbour to influence inbound (for example, MED and AS_PATH), and tie-breakers, where BGP picks something stable when your policy doesn’t decide.
 
+> Sidebar: the BGP path selection algorithm (and where it actually applies)
+>
+> It’s easy to read a “BGP best path” list and assume BGP is making a global routing decision across your whole table. It isn’t.
+>
+> The important nuance is that the BGP path selection algorithm only runs when you have multiple candidate paths for the same prefix, and it’s effectively comparing like-for-like. Longest Prefix Match (LPM) happens first, which means the “BGP decision process” is, in practice, mostly about choosing between routes of the same prefix length.
+>
+> That’s one of the reasons providers often enforce a minimum, maximum, or fixed acceptable prefix length in their routing policy. They’re trying to keep the routing domain sane, and they’re also trying to avoid customers using more-specific prefixes as a cheap trick to bypass policy and traffic engineering.
+>
+> If you want the rationale for why prefix length wins before any BGP attribute, and why we shouldn’t abuse it, this post is the best explanation I’ve written: https://www.simonpainter.com/longest-prefix-matching/
+>
+> Vendor note: the exact tie-break order differs slightly between implementations, and there are knobs to change it. Junos has a good write-up here, including its default MED comparison behaviour and the options that alter it: https://www.juniper.net/documentation/us/en/software/junos/vpn-l2/bgp/topics/concept/routing-protocols-address-representation.html
+
 ### The three attributes you’ll use constantly
 
 The three attributes you’ll use constantly are LOCAL_PREF, which is your strongest tool for choosing the outbound exit inside your AS, AS_PATH, which is one of the few levers that naturally propagates beyond your first-hop peer, and MED, which is a hint to a neighbour, with limits.

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -32,8 +32,7 @@ BGP is also **policy-first**. It’s designed for environments where “best” 
 :::note “BGP isn’t an IGP”… except when it is.
 In most enterprise networks, BGP isn’t used as an IGP. But at very large scale (I’ve seen this first-hand at Walmart), some organisations do run BGP internally because the scaling and operational trade-offs can work out better than running a giant link-state domain.
 
-If you want the deeper reasoning: I wrote about OSPF scaling constraints and why BGP scales differently here:
-https://www.simonpainter.com/dijkstra-ospf/
+If you want the deeper reasoning: I wrote about [OSPF scaling constraints and why BGP scales differently](dijkstra-ospf.md).
 :::
 
 ## eBGP and iBGP at the cloud edge
@@ -277,7 +276,7 @@ Microsoft-side BGP timers are fixed (keepalive and hold), so fast failover is no
 
 Filtering is primarily your responsibility on the on-prem edge. Azure UDRs are static and not part of BGP advertisement. On Microsoft peering specifically, “no routes” is often explained by a missing route filter.
 
-References: circuit peerings and BGP behaviour (<https://learn.microsoft.com/en-us/azure/expressroute/expressroute-circuit-peerings>), ExpressRoute FAQs (<https://learn.microsoft.com/en-us/azure/expressroute/expressroute-faqs>), resiliency guidance (<https://learn.microsoft.com/en-us/azure/expressroute/design-architecture-for-resiliency>), and troubleshooting performance (<https://learn.microsoft.com/en-us/troubleshoot/azure/expressroute/expressroute-troubleshooting-network-performance>).
+References: [circuit peerings and BGP behaviour](https://learn.microsoft.com/en-us/azure/expressroute/expressroute-circuit-peerings), [ExpressRoute FAQs](https://learn.microsoft.com/en-us/azure/expressroute/expressroute-faqs), [resiliency guidance](https://learn.microsoft.com/en-us/azure/expressroute/design-architecture-for-resiliency), and [troubleshooting performance](https://learn.microsoft.com/en-us/troubleshoot/azure/expressroute/expressroute-troubleshooting-network-performance).
 :::
 
 ### Private ASN vs public ASN (enterprise reality)
@@ -362,11 +361,11 @@ The important nuance is that the BGP path selection algorithm only runs when you
 
 That’s one of the reasons providers often enforce a minimum, maximum, or fixed acceptable prefix length in their routing policy. They’re trying to keep the routing domain sane, and they’re also trying to avoid customers using more-specific prefixes as a cheap trick to bypass policy and traffic engineering.
 
-If you want the rationale for why prefix length wins before any BGP attribute, and why we shouldn’t abuse it, this post is the best explanation I’ve written: https://www.simonpainter.com/longest-prefix-matching/
+If you want the rationale for why prefix length wins before any BGP attribute, and why we shouldn’t abuse it, this post is my attempt to explain: [Longest Prefix Matching](https://www.simonpainter.com/longest-prefix-matching/).
 
-Vendor note: the exact tie-break order differs slightly between implementations, and there are knobs to change it. Junos has a good write-up here, including its default MED comparison behaviour and the options that alter it: https://www.juniper.net/documentation/us/en/software/junos/vpn-l2/bgp/topics/concept/routing-protocols-address-representation.html
+Vendor note: the exact tie-break order differs slightly between implementations, and there are knobs to change it. Junos has a good write-up here, including its default MED comparison behaviour and the options that alter it: [Junos BGP Documentation](https://www.juniper.net/documentation/us/en/software/junos/vpn-l2/bgp/topics/concept/routing-protocols-address-representation.html)
 
-Cisco has a canonical write-up too (and it’s a good reminder that Cisco has router-local attributes like WEIGHT that don’t exist everywhere): https://www.cisco.com/c/en/us/support/docs/ip/border-gateway-protocol-bgp/13753-25.html
+Cisco has a canonical write-up too (and it’s a good reminder that Cisco has router-local attributes like WEIGHT that don’t exist everywhere): [Cisco BGP Documentation](https://www.cisco.com/c/en/us/support/docs/ip/border-gateway-protocol-bgp/13753-25.html)
 :::
 
 ### The three attributes you’ll use constantly
@@ -572,8 +571,7 @@ BGP communities are one of the most useful “provider-supported knobs”, but t
 
 They’re often the cleanest way to do inbound steering because the provider can map a community to an explicit internal policy (for example, changing local preference on their side).
 
-I’ve written a more detailed comparison of how Azure and AWS use communities here:
-https://www.simonpainter.com/community-comparison/
+I’ve written a [more detailed comparison](community-comparison.md) of how Azure and AWS use communities.
 
 ## BGP communities
 
@@ -603,9 +601,7 @@ The exact values are provider-specific, but the themes repeat. You’ll see comm
 
 AWS and Azure both use communities heavily, but the models differ.
 
-Rather than duplicating provider tables here, I’ve written up a comparison (including examples like NO_EXPORT usage, regional scoping, and preference communities) in a dedicated post:
-
-https://www.simonpainter.com/community-comparison/
+Rather than duplicating provider tables here, I’ve [written up a comparison](community-comparison.md) (including examples like NO_EXPORT usage, regional scoping, and preference communities) in a dedicated post.
 
 ### Practical advice
 
@@ -775,7 +771,7 @@ flowchart LR
   %% Without export filtering you can accidentally become transit (A <-> you <-> B).
 ```
 
-**IOS-XE (illustrative)**
+### IOS-XE (illustrative)
 
 ```ios
 ip prefix-list MY-PREFIXES seq 10 permit 203.0.113.0/24
@@ -793,7 +789,7 @@ router bgp 65001
  neighbor 198.51.100.2 route-map EXPORT-ONLY-MY-PREFIXES out
 ```
 
-**JunOS (illustrative)**
+### JunOS (illustrative)
 
 ```junos
 policy-options {
@@ -842,7 +838,7 @@ On the other hand, in some **private multi-cloud CNF** designs, you might _delib
 In the public internet, routing policy is often described using RPSL objects (route/route6, aut-num, etc.), which are then used to build prefix filters.
 It’s one of the reasons “who should accept what from whom” can be automated at scale.
 
-If you’ve never bumped into it before: https://en.wikipedia.org/wiki/Routing_Policy_Specification_Language
+If you’ve never bumped into it before: [Routing Policy Specification Language](https://en.wikipedia.org/wiki/Routing_Policy_Specification_Language)
 
 Sidebar: a quick note on RPKI and route validation
 
@@ -850,15 +846,14 @@ RPKI is the mechanism that lets prefix holders publish cryptographic Route Origi
 
 Even if your enterprise BGP is mostly “private”, the upstreams you depend on operate in the public routing system, and the industry is increasingly treating RPKI-invalid routes as something to drop, not just something to log.
 
-AWS has a good high-level write-up of what they’re doing here, which is useful context: https://aws.amazon.com/blogs/networking-and-content-delivery/how-aws-is-helping-to-secure-internet-routing/
+AWS has a good high-level write-up of what they’re doing here, which is useful context: [How AWS is helping to secure internet routing](https://aws.amazon.com/blogs/networking-and-content-delivery/how-aws-is-helping-to-secure-internet-routing/)
 :::
 
 :::note how Azure prevents some transit scenarios
 Microsoft actively prevents certain transit-routing behaviours in the backbone (for good reasons).
 If you’re using Route Server + ExpressRoute in multi-hub designs, this can show up as “routes learned in one place aren’t propagated to another” when a shared circuit is involved.
 
-I wrote up the behaviour and the design implications here:
-https://www.simonpainter.com/transit-route-prevention/
+I wrote up [the behaviour and the design implications](transit-route-prevention.md).
 :::
 
 ### Max-prefix
@@ -911,27 +906,26 @@ BGP is no longer only about Direct Connect at the edge. AWS now has constructs w
 
 A good example is Amazon VPC Route Server, which can use BGP to influence route tables (including IGW route tables) for patterns like floating IP failover, or steering traffic through active/standby inspection appliances.
 
-Useful starting point: <https://aws.amazon.com/blogs/networking-and-content-delivery/dynamic-routing-using-amazon-vpc-route-server/>
+Useful starting point: [Dynamic Routing Using Amazon VPC Route Server](https://aws.amazon.com/blogs/networking-and-content-delivery/dynamic-routing-using-amazon-vpc-route-server/)
 :::
 
 :::note AWS Cloud WAN Connect and MP-BGP reality
 If you’re integrating SD-WAN or building a global enterprise WAN overlay, AWS Cloud WAN Connect is another place BGP shows up. It’s also a good reminder that modern enterprise designs often exchange IPv6 routes over MP-BGP, even when the BGP adjacency itself is IPv4.
 
-Reference: <https://aws.amazon.com/blogs/networking-and-content-delivery/building-resilient-ipv6-network-with-sd-wans-and-aws-cloud-wan-connect-with-gre/>
+Reference: [Building a Resilient IPv6 Network with SD-WANs and AWS Cloud WAN Connect with GRE](https://aws.amazon.com/blogs/networking-and-content-delivery/building-resilient-ipv6-network-with-sd-wans-and-aws-cloud-wan-connect-with-gre/)
 :::
 
 :::note prove your resiliency, don’t just design it
 BGP failover only matters if you’ve tested it. AWS provides guidance and tooling for deliberately failing over Direct Connect virtual interfaces, which makes it easier to run proper game-days.
 
-Reference: <https://aws.amazon.com/blogs/networking-and-content-delivery/testing-aws-direct-connect-resiliency-with-resiliency-toolkit-failover-testing/>
+Reference: [Testing AWS Direct Connect Resiliency with Resiliency Toolkit Failover Testing](https://aws.amazon.com/blogs/networking-and-content-delivery/testing-aws-direct-connect-resiliency-with-resiliency-toolkit-failover-testing/)
 :::
 
 ### Route Server (brief pointer)
 
 If you’re using managed route distribution services (like Azure Route Server), you’ll run into platform constraints that exist specifically to prevent certain transit patterns.
 
-I’ve written up one of the key behaviours and its design implications here:
-https://www.simonpainter.com/transit-route-prevention/
+I’ve written up [one of the key behaviours](transit-route-prevention.md) and its design implications.
 
 :::note AWS Route Server versus Azure Route Server
 AWS Route Server and Azure Route Server sound like the same thing, but they aren’t.
@@ -940,7 +934,7 @@ Azure Route Server is closer to “BGP as a Service”, it peers using standard 
 
 AWS Route Server is a more specialised tool, it is primarily about orchestrating active/passive appliance failover by manipulating specific route tables, and it is deliberately non-transitive.
 
-If you want the deeper comparison (and the philosophy behind the difference), I wrote it up here: https://www.simonpainter.com/aws-route-server/
+If you want the deeper comparison (and the philosophy behind the difference), I wrote it up here: [AWS Route Server vs Azure Route Server](https://www.simonpainter.com/aws-route-server/)
 :::
 
 ## Wrapping up

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -12,7 +12,7 @@ date: 2026-03-15
 draft: true
 ---
 
-I used to joke that the cloud networking exams, AZ-700 for Azure, and AWS Advanced Networking, were mostly just _“BGP in a GUI”_.
+I used to joke that the cloud networking exams, [AZ-700 for Azure](https://learn.microsoft.com/en-us/users/simonpainter/credentials/901c10b6d2135de3?ref=https%3A%2F%2Fwww.linkedin.com%2F), and [AWS Advanced Networking](https://www.credly.com/badges/5b413a12-1d38-4487-b36c-2fa470771a70), were mostly just _“BGP in a GUI”_.
 
 It’s not really true. Both exams cover a lot more than that: security, load balancers, DNS, design patterns… the works.
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -109,6 +109,33 @@ There are a few common ways MPLS WAN providers present routing. The exact implem
 
 This is the “textbook” model. Your CE runs eBGP to the provider PE. The provider PE is in the provider’s ASN, so you see the provider AS in the AS_PATH (or at least you can). Your routes are imported into the provider’s MPLS VPN routing domain and distributed to other sites.
 
+```mermaid
+flowchart LR
+  subgraph SiteA[Site A]
+    CE1[CE Router]
+    LAN1[LAN prefixes]
+    LAN1 --> CE1
+  end
+
+  subgraph Provider[Provider MPLS Core]
+    PE1[PE Router]
+    MPLS[(MPLS / L3VPN Core)]
+    PE2[PE Router]
+  end
+
+  subgraph SiteB[Site B]
+    CE2[CE Router]
+    LAN2[LAN prefixes]
+    CE2 --> LAN2
+  end
+
+  CE1 -- eBGP (PE/CE) --> PE1
+  PE1 --> MPLS --> PE2
+  PE2 -- eBGP (PE/CE) --> CE2
+
+  %% provider distributes customer routes inside the VPN routing domain
+```
+
 Why this matters for the cloud journey: this is the closest mental model to DX/ER peering.
 
 #### Pattern B (sidebar): CE–CE peering over MPLS (customer edges peer with each other)
@@ -160,6 +187,35 @@ That transport could be an MPLS or SD-WAN underlay, ExpressRoute or Direct Conne
 ### What’s actually peering with what?
 
 In the model we’re using for this post, your routers sit in one (or two) CNFs, you have L2 to each provider peer, and you run eBGP to Azure (ExpressRoute private peering), AWS (Direct Connect private VIF), and optionally your WAN provider(s) if you’re also aggregating MPLS or SD-WAN there.
+
+```mermaid
+flowchart TB
+  subgraph CNF[Cloud Exchange / CNF]
+    ER1[Edge Router A]
+    ER2[Edge Router B]
+  end
+
+  subgraph Cloud[Cloud Providers]
+    AZ[Azure ER Peer]
+    AWS[AWS DX Peer]
+  end
+
+  subgraph Enterprise[Enterprise Network]
+    Core[Core / RR / IGP]
+    Sites[DCs, campuses, branches]
+  end
+
+  ER1 -- eBGP --> AZ
+  ER1 -- eBGP --> AWS
+  ER2 -- eBGP --> AZ
+  ER2 -- eBGP --> AWS
+
+  ER1 -- iBGP / redistribute --> Core
+  ER2 -- iBGP / redistribute --> Core
+  Core --> Sites
+
+  %% CNF provides L2 handoff to the cloud peers
+```
 
 On the enterprise side, you then need to decide how those routes get back into the rest of your network. That usually means iBGP to a core pair or route reflectors, or redistribution into an IGP (with all the caveats that implies).
 
@@ -297,6 +353,16 @@ It’s popular for three reasons: it’s deterministic, it’s simple to reason 
 
 This is the bread-and-butter enterprise requirement. You learn the same (or overlapping) routes from two upstreams or two circuits, you want all outbound traffic to prefer circuit A, and if A fails you want traffic to move to B.
 
+```mermaid
+flowchart LR
+  LAN[Enterprise prefixes] --> R[Your Router]
+  R -- eBGP --> ISP1[Provider / Cloud Peer A]
+  R -- eBGP --> ISP2[Provider / Cloud Peer B]
+
+  %% Outbound: set higher LOCAL_PREF on routes learned via A
+  %% Failover: when A withdraws, B remains
+```
+
 Mechanically, you do this by matching the routes you learn from neighbour A and setting a higher LOCAL_PREF, and leaving neighbour B at a lower LOCAL_PREF.
 
 ### IOS-XE example (set LOCAL_PREF higher for routes learned from preferred peer)
@@ -351,8 +417,7 @@ A few practical notes: in real configs you’ll almost always include explicit r
 ## TODO: diagrams
 Add Mermaid diagrams for each architectural example or pattern in this post (MPLS patterns, dual circuits, CNF designs, and so on).
 
-## TODO: style pass
-Replace em dashes (the long dash character) with commas or semicolons where appropriate. Reduce bulleted lists, and prefer prose paragraphs (comma-separated lists where it reads well). Use the Oxford comma in all comma-separated lists.
+Style pass notes: em dashes removed, bulleted lists reduced, Oxford comma used where it reads naturally. Remaining work is mostly diagrams and final polish.
 
 ## 8) Influencing inbound traffic (enterprise reality)
 
@@ -405,6 +470,19 @@ A practical way to think about prepend is that it’s good for “prefer this ci
 ### Putting it together: two links to the same provider
 
 This is the classic enterprise ask. Outbound is “prefer circuit A, keep B as backup” (LOCAL_PREF), and inbound is “encourage the provider to send traffic to you via circuit A”.
+
+```mermaid
+flowchart LR
+  Internet[(Users / Internet)] --> P[Provider AS]
+  P -->|Link A| CE1[Your Edge]
+  P -->|Link B| CE2[Your Edge]
+
+  CE1 --> LAN[Your prefixes]
+  CE2 --> LAN
+
+  %% Inbound: provider decides path towards you
+  %% Tools: communities (cleanest), MED (if honoured), AS_PATH prepend (portable)
+```
 A pragmatic ordering is:
 
 1) If you have a provider-supported inbound knob (often communities): use that.
@@ -472,6 +550,36 @@ The assumption for the examples in this post is that you host your own routers i
 ### Two-CNF diversity (why it’s common)
 
 A common pattern is to use two CNFs for physical and geographic diversity, for example separate meet-me rooms, separate fibre paths, and separate power domains and blast radius.
+
+```mermaid
+flowchart TB
+  subgraph CNF1[CNF 1]
+    E1[Edge Router]
+  end
+
+  subgraph CNF2[CNF 2]
+    E2[Edge Router]
+  end
+
+  subgraph Clouds[Cloud peers]
+    AZ[Azure ER Peer]
+    AWS[AWS DX Peer]
+  end
+
+  subgraph Ent[Enterprise]
+    Core[Core / RR]
+  end
+
+  E1 -- eBGP --> AZ
+  E1 -- eBGP --> AWS
+  E2 -- eBGP --> AZ
+  E2 -- eBGP --> AWS
+
+  E1 -- iBGP / internal --> Core
+  E2 -- iBGP / internal --> Core
+
+  %% Two CNFs give physical diversity, BGP policy decides preference and failover
+```
 
 You then decide whether the design is active/active northbound (both CNFs have cloud peers up), or active/passive (one CNF is preferred, and the other is failover).
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -421,6 +421,7 @@ A few practical notes:
 ## TODO: style pass
 - Replace **em dashes (—)** with commas or semicolons where appropriate.
 - Reduce **bulleted lists**; prefer prose paragraphs (comma-separated lists where it reads well).
+- Use the **Oxford comma** in all comma-separated lists.
 
 ## 8) Influencing inbound traffic (enterprise reality)
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -757,10 +757,40 @@ On the other hand, in some **private multi-cloud CNF** designs, you might *delib
 > https://www.simonpainter.com/transit-route-prevention/
 
 ### Max-prefix
-(TODO)
+
+Max-prefix is your seatbelt.
+
+It limits how many routes you’re willing to accept from a neighbour.
+If you expected “a few hundred prefixes” and you suddenly receive “the full internet”, max-prefix can stop that mistake becoming a widespread outage.
+
+A pragmatic enterprise approach is:
+- set max-prefix on every eBGP peer
+- set the threshold based on what you *expect* (plus headroom)
+- decide the failure mode:
+  - warn-only (log) vs
+  - hard-teardown (drop the session)
+
+> If you’re peering with an upstream that can legitimately send you huge tables (e.g., full routes), max-prefix is still useful — you just size it appropriately.
 
 ### Route refresh / soft reconfig basics
-(TODO)
+
+Modern BGP gives you ways to change policy without bouncing the session.
+This matters operationally because:
+- bouncing a session can cause unnecessary convergence churn
+- and on some designs it can cause traffic loss while paths re-learn
+
+Two concepts you’ll see:
+
+- **Route Refresh**: a capability where you can ask a neighbour to resend routes after you change policy.
+- **Soft reconfiguration**: keeping enough state to re-evaluate routes against new policy without a hard reset.
+
+The exact commands differ (IOS-XE vs JunOS), but the operational goal is the same:
+- change filter/policy
+- refresh routes
+- confirm the new bestpaths
+
+If your platform supports route refresh, use it.
+If it doesn’t, you’ll end up doing some kind of clear/reset — just do it intentionally and during a safe window.
 
 ## 12) Cloud specifics (light touch)
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -409,6 +409,9 @@ A few practical notes:
 - In real configs you’ll almost always include **explicit route filters** (prefix-lists) alongside these policies.
 - If you want active/active, LOCAL_PREF can still be used — you just set them equal and rely on other mechanisms (or ECMP capability) to load-share.
 
+## TODO: diagrams
+- Add **Mermaid diagrams** for each architectural example/pattern in this post (MPLS patterns, dual circuits, CNF designs, etc.).
+
 ## 8) Influencing inbound traffic (enterprise reality)
 
 ### Why inbound is harder

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -187,6 +187,8 @@ Why this matters for the cloud journey: this is the closest mental model to Dire
 
 ### ASNs in MPLS enterprise designs
 
+How you assign ASNs across your sites has a direct impact on loop prevention and route propagation. There are two common models.
+
 #### Per-site ASNs
 
 A very common enterprise pattern is:

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -71,7 +71,7 @@ You don’t need them in a small design, but once you have “lots of BGP speake
 
 ### Why you care
 
-Because **your operational knobs behave differently depending on where you are**. LOCAL_PREF is your best “pick the outbound exit” tool, but it’s only meaningful inside your AS. MED is, at best, a hint to a neighbour, and it is typically only compared in narrow conditions. AS_PATH prepending is crude, but it’s one of the few signals that naturally propagates beyond your first-hop peer.
+Because **your operational controls behave differently depending on where you are**. LOCAL_PREF is your best “pick the outbound exit” tool, but it’s only meaningful inside your AS. MED is, at best, a hint to a neighbour, and it is typically only compared in narrow conditions. AS_PATH prepending is crude, but it’s one of the few signals that naturally propagates beyond your first-hop peer.
 
 :::note iBGP, eBGP, and where they sit in the route selection hierarchy
 There are two different “selection” processes people conflate.
@@ -346,7 +346,7 @@ BGP path selection looks intimidating until you realise two things:
 1. most of the decision process only matters when you have multiple candidate routes to the _same_ prefix, and
 2. in enterprise designs you tend to use a small handful of attributes deliberately.
 
-We’ll keep this vendor-neutral and focus on the knobs you’ll actually touch at a cloud/WAN edge.
+We’ll keep this vendor-neutral and focus on the tools you’ll actually use at a cloud and WAN edge.
 
 ### The simplified mental model
 
@@ -363,7 +363,7 @@ That’s one of the reasons providers often enforce a minimum, maximum, or fixed
 
 If you want the rationale for why prefix length wins before any BGP attribute, and why we shouldn’t abuse it, this post is my attempt to explain: [Longest Prefix Matching](https://www.simonpainter.com/longest-prefix-matching/).
 
-Vendor note: the exact tie-break order differs slightly between implementations, and there are knobs to change it. Junos has a good write-up here, including its default MED comparison behaviour and the options that alter it: [Junos BGP Documentation](https://www.juniper.net/documentation/us/en/software/junos/vpn-l2/bgp/topics/concept/routing-protocols-address-representation.html)
+Vendor note: the exact tie-break order differs slightly between implementations, and there are settings that can change it. Junos has a good write-up here, including its default MED comparison behaviour and the options that alter it: [Junos BGP Documentation](https://www.juniper.net/documentation/us/en/software/junos/vpn-l2/bgp/topics/concept/routing-protocols-address-representation.html)
 
 Cisco has a canonical write-up too (and it’s a good reminder that Cisco has router-local attributes like WEIGHT that don’t exist everywhere): [Cisco BGP Documentation](https://www.cisco.com/c/en/us/support/docs/ip/border-gateway-protocol-bgp/13753-25.html)
 :::
@@ -374,7 +374,7 @@ The three attributes you’ll use constantly are LOCAL_PREF, which is your stron
 
 I’ll go deeper on how to use each of these in [Steering outbound traffic](#steering-outbound-traffic) and [Influencing inbound traffic](#influencing-inbound-traffic).
 
-### Real-world scenarios we’ll map onto these knobs
+### Real-world scenarios we’ll map onto these tools
 
 These come up constantly in enterprise cloud/WAN designs:
 
@@ -390,7 +390,7 @@ These come up constantly in enterprise cloud/WAN designs:
 
 3. **Two private ASNs (two edges) peered to a single remote ASN, and you want end-to-end path control**
    - The tricky bit: LOCAL_PREF and MED don’t travel “downstream”.
-   - The portable lever: AS_PATH signals (and, where supported, community-based knobs).
+   - The portable lever: AS_PATH signals (and, where supported, community-based controls).
 
 We’ll work through these explicitly as we go.
 
@@ -567,7 +567,7 @@ Failures, maintenance, hot-potato routing and upstream policy all get a vote.
 
 ### Communities (conceptual)
 
-BGP communities are one of the most useful “provider-supported knobs”, but they’re still _influence_, not control.
+BGP communities are one of the most useful “provider-supported tools”, but they’re still _influence_, not control.
 
 They’re often the cleanest way to do inbound steering because the provider can map a community to an explicit internal policy (for example, changing local preference on their side).
 
@@ -899,7 +899,7 @@ Some practical differences you’ll feel are that you’re peering to a cloud se
 
 Public peering options exist too, and they come with sharp edges. DX public VIF and ER Microsoft peering can be great for predictable paths to public services, but they’re also where you really don’t want to accidentally export something that turns you into transit.
 
-Finally, availability patterns are “product-shaped”. You’ll often have multiple BGP sessions per circuit, dual circuits, and region and site diversity patterns. The BGP knobs are the same, but the constraints around them are not.
+Finally, availability patterns are “product-shaped”. You’ll often have multiple BGP sessions per circuit, dual circuits, and region and site diversity patterns. The BGP controls are the same, but the constraints around them are not.
 
 :::note BGP inside AWS constructs (it’s not just a hybrid edge protocol)
 BGP is no longer only about Direct Connect at the edge. AWS now has constructs where BGP drives changes inside the VPC routing domain.

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -187,7 +187,7 @@ Why this matters for the cloud journey: this is the closest mental model to Dire
 
 ### ASNs in MPLS enterprise designs
 
-### Per-site ASNs
+#### Per-site ASNs
 
 A very common enterprise pattern is:
 
@@ -196,7 +196,7 @@ A very common enterprise pattern is:
 
 It’s convenient because it keeps the eBGP loop-prevention behaviour simple: every site is “a different AS”, so re-advertisement between sites doesn’t trip over “I see myself in the AS_PATH”.
 
-### Single ASN across all sites (and why private-AS stripping matters)
+#### Single ASN across all sites (and why private-AS stripping matters)
 
 It’s equally valid to run **the same ASN at every site**.
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -11,7 +11,7 @@ date: 2026-03-15
 draft: true
 ---
 
-I used to joke that the cloud networking exams — AZ-700 for Azure, and AWS Advanced Networking — were mostly just *“BGP in a GUI”*.
+I used to joke that the cloud networking exams, AZ-700 for Azure, and AWS Advanced Networking, were mostly just *“BGP in a GUI”*.
 
 It’s not really true. Both exams cover a lot more than that: security, load balancers, DNS, design patterns… the works.
 
@@ -19,7 +19,7 @@ But the joke exists for a reason: as soon as you get into hybrid connectivity an
 
 And it’s not fair to assume that every enterprise network engineer has spent years living in BGP. Plenty of excellent network engineers can build entire careers with only a light touch of it (often just “peer to the MPLS provider and move on”).
 
-So this post is an explainer of the key BGP concepts that an enterprise network engineer needs to feel comfortable designing and operating **hybrid, multi-cloud connectivity** — where BGP plays its vital role.
+So this post is an explainer of the key BGP concepts that an enterprise network engineer needs to feel comfortable designing and operating **hybrid, multi-cloud connectivity**, where BGP plays its vital role.
 
 <!--truncate-->
 
@@ -89,7 +89,7 @@ If you understand the eBGP/iBGP boundary, the rest of BGP becomes much less myst
 ## 3) Where enterprise engineers have seen BGP before: MPLS WAN patterns
 
 For a lot of enterprise folks, “BGP experience” starts and ends with *an MPLS circuit*.
-That’s fine — but it can leave you with some slightly warped assumptions, because MPLS providers can make BGP look like anything from “a normal eBGP peer” to “a magic ethernet cable between sites”.
+That’s fine, but it can leave you with some slightly warped assumptions, because MPLS providers can make BGP look like anything from “a normal eBGP peer” to “a magic ethernet cable between sites”.
 
 ### Managed CEs (you might never have seen the BGP config)
 
@@ -98,7 +98,7 @@ Plenty of enterprises buy **managed CE routers**. In that model:
 - you may only see a handoff (LAN interface / VLAN),
 - and you might never touch BGP at all.
 
-Mechanically, BGP is still often involved somewhere — it’s just **not your problem** until the day you add cloud connectivity and suddenly it is.
+Mechanically, BGP is still often involved somewhere, but it’s just **not your problem** until the day you add cloud connectivity, and suddenly it is.
 
 ### Common MPLS patterns (abstract mechanics)
 
@@ -116,7 +116,7 @@ Why this matters for the cloud journey: this is the closest mental model to DX/E
 
 #### Pattern B (sidebar): CE–CE peering over MPLS (customer edges peer with each other)
 
-> This is **not the typical MPLS model** — most MPLS WANs are built as a many-to-many L3VPN where you peer to the provider and the provider does the route distribution.
+> This is **not the typical MPLS model**; most MPLS WANs are built as a many-to-many L3VPN where you peer to the provider, and the provider does the route distribution.
 >
 > That said, I *have* seen real-world deployments where the MPLS network is treated as **a transport underlay**, and the **customer edge routers form BGP adjacencies with each other**.
 >
@@ -126,7 +126,7 @@ Why this matters for the cloud journey: this is the closest mental model to DX/E
 >
 > What has to be true for it to work:
 > - The provider must provide **IP reachability between CEs** (it’s effectively giving you a routed any-to-any service), and
-> - the provider is **not** doing your inter-site route exchange for you — *your BGP* is.
+> - the provider is **not** doing your inter-site route exchange for you; *your BGP* is.
 >
 > This pattern is conceptually closer to “running your own WAN overlay” than to classic managed MPLS L3VPN routing.
 
@@ -148,7 +148,7 @@ But you need to understand one hard rule:
 
 - If site A advertises a prefix to the WAN, and that route is later presented to site B *with the same ASN still in the AS_PATH*, then **site B will drop it**.
 
-That’s not a bug — that’s BGP doing loop prevention: *“I won’t accept a route that already contains my ASN.”*
+That’s not a bug; that’s BGP doing loop prevention: *“I won’t accept a route that already contains my ASN.”*
 
 So if you run “single ASN everywhere” using a private ASN, the provider typically has to do **private-AS removal/stripping** between sites.
 
@@ -221,7 +221,7 @@ That’s why a lot of BGP guidance boils down to:
 ## 5) Route advertisement basics (what you advertise and why)
 
 This is where most real-world BGP outages come from.
-Not because someone misunderstood the BGP decision process — but because someone advertised (or accepted) more routes than they intended.
+Not because someone misunderstood the BGP decision process, but because someone advertised (or accepted) more routes than they intended.
 
 ### “Less is more”
 
@@ -334,7 +334,7 @@ We’ll work through these explicitly as we go.
 ## 7) Influencing outbound traffic (enterprise reality)
 
 Outbound is the part you *actually* control.
-If you’re deciding which circuit you want to use to *leave your network*, BGP gives you a few options — but in enterprise designs **LOCAL_PREF** is the one you’ll use constantly.
+If you’re deciding which circuit you want to use to *leave your network*, BGP gives you a few options, but in enterprise designs **LOCAL_PREF** is the one you’ll use constantly.
 
 ### LOCAL_PREF (the clean internal lever)
 
@@ -350,7 +350,7 @@ It’s popular for three reasons:
 >
 > ECMP (active/active) has real value, but plenty of real networks have stateful firewalls or NAT devices that **aren’t clustered**.
 > Those designs often require **symmetric paths** (same in and out) to avoid breaking sessions.
-> In that world, active/passive circuits aren’t a failure of imagination — they’re a pragmatic requirement.
+> In that world, active/passive circuits aren’t a failure of imagination; they’re a pragmatic requirement.
 
 ### Pattern: prefer exit A, keep exit B as backup
 
@@ -413,13 +413,13 @@ protocols {
 
 A few practical notes:
 - In real configs you’ll almost always include **explicit route filters** (prefix-lists) alongside these policies.
-- If you want active/active, LOCAL_PREF can still be used — you just set them equal and rely on other mechanisms (or ECMP capability) to load-share.
+- If you want active/active, LOCAL_PREF can still be used; you just set them equal, and rely on other mechanisms (or ECMP capability) to load-share.
 
 ## TODO: diagrams
 - Add **Mermaid diagrams** for each architectural example/pattern in this post (MPLS patterns, dual circuits, CNF designs, etc.).
 
 ## TODO: style pass
-- Replace **em dashes (—)** with commas or semicolons where appropriate.
+- Replace em dashes (the long dash character) with commas or semicolons where appropriate.
 - Reduce **bulleted lists**; prefer prose paragraphs (comma-separated lists where it reads well).
 - Use the **Oxford comma** in all comma-separated lists.
 
@@ -744,7 +744,7 @@ The same principle applies to **public cloud public-peering** models:
 
 On the other hand, in some **private multi-cloud CNF** designs, you might *deliberately* act as a transit:
 - e.g., allow private traffic from Cloud A to reach Cloud B via your exchange routers.
-- That’s a valid architecture — but only if you do it intentionally and keep it isolated from public-routing domains.
+- That’s a valid architecture, but only if you do it intentionally, and keep it isolated from public-routing domains.
 
 > Sidebar: RPSL (Routing Policy Specification Language)
 >
@@ -775,7 +775,7 @@ A pragmatic enterprise approach is:
   - warn-only (log) vs
   - hard-teardown (drop the session)
 
-> If you’re peering with an upstream that can legitimately send you huge tables (e.g., full routes), max-prefix is still useful — you just size it appropriately.
+> If you’re peering with an upstream that can legitimately send you huge tables (e.g., full routes), max-prefix is still useful; you just size it appropriately.
 
 ### Route refresh / soft reconfig basics
 
@@ -795,7 +795,7 @@ The exact commands differ (IOS-XE vs JunOS), but the operational goal is the sam
 - confirm the new bestpaths
 
 If your platform supports route refresh, use it.
-If it doesn’t, you’ll end up doing some kind of clear/reset — just do it intentionally and during a safe window.
+If it doesn’t, you’ll end up doing some kind of clear/reset; just do it intentionally, and during a safe window.
 
 ## 12) Cloud specifics (light touch)
 
@@ -837,4 +837,4 @@ But enterprise cloud connectivity only needs a subset:
 - use communities when the provider documents them
 - and put safety rails around import/export so you don’t leak routes or accidentally become transit
 
-If you get those right, you’ll be able to design hybrid multi-cloud connectivity that behaves predictably — and when it doesn’t, you’ll know where to look.
+If you get those right, you’ll be able to design hybrid multi-cloud connectivity that behaves predictably, and when it doesn’t, you’ll know where to look.

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -158,6 +158,32 @@ Why this matters for the cloud journey: this is the closest mental model to DX/E
 > - the provider is **not** doing your inter-site route exchange for you; *your BGP* is.
 >
 > This pattern is conceptually closer to “running your own WAN overlay” than to classic managed MPLS L3VPN routing.
+>
+> ```mermaid
+> %%{init: {'theme':'neutral','flowchart':{'curve':'basis'},'themeVariables':{'fontFamily':'Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial'}}}%%
+> flowchart LR
+>   classDef enterprise fill:#E8F1FF,stroke:#2F6FED,stroke-width:1px,color:#0B1F44;
+>   classDef provider fill:#FFF3E0,stroke:#F59E0B,stroke-width:1px,color:#3B2F00;
+>   classDef edge fill:#F3E8FF,stroke:#8B5CF6,stroke-width:1px,color:#2E1065;
+>
+>   subgraph SiteA[Site A]
+>     CE1[CE Router]:::edge
+>   end
+>
+>   subgraph Provider[Provider MPLS Underlay]
+>     MPLS[(Transport only)]:::provider
+>   end
+>
+>   subgraph SiteB[Site B]
+>     CE2[CE Router]:::edge
+>   end
+>
+>   CE1 -- BGP adjacency --> CE2
+>   CE1 -. IP reachability via underlay .- MPLS
+>   CE2 -. IP reachability via underlay .- MPLS
+>
+>   %% Customer CEs run the control plane; provider provides reachability.
+> ```
 
 ### ASNs in MPLS enterprise designs
 
@@ -429,10 +455,9 @@ protocols {
 
 A few practical notes: in real configs you’ll almost always include explicit route filters (prefix-lists) alongside these policies. If you want active/active, LOCAL_PREF can still be used; you just set them equal, and rely on other mechanisms (or ECMP capability) to load-share.
 
-## TODO: diagrams
-Add Mermaid diagrams for each architectural example or pattern in this post (MPLS patterns, dual circuits, CNF designs, and so on).
+## Diagrams
 
-Style pass notes: em dashes removed, bulleted lists reduced, Oxford comma used where it reads naturally. Remaining work is mostly diagrams and final polish.
+This post includes Mermaid diagrams for the key architectural patterns. If I’ve missed an example you care about, it’s usually a sign I should diagram it out.
 
 ## 8) Influencing inbound traffic (enterprise reality)
 
@@ -638,6 +663,39 @@ The key mental model is that if the decision is happening inside one of your ASN
 
 This is also where it becomes crucial to separate what you want for outbound (easy), what you want for inbound (hard), and what your failure mode is (the thing that makes the design real).
 
+```mermaid
+%%{init: {'theme':'neutral','flowchart':{'curve':'basis'},'themeVariables':{'fontFamily':'Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial'}}}%%
+flowchart LR
+  classDef enterprise fill:#E8F1FF,stroke:#2F6FED,stroke-width:1px,color:#0B1F44;
+  classDef cloud fill:#E7F8EF,stroke:#10B981,stroke-width:1px,color:#05361F;
+  classDef edge fill:#F3E8FF,stroke:#8B5CF6,stroke-width:1px,color:#2E1065;
+
+  subgraph CNF_A[CNF A, ASN 65001]
+    A[Edge router A]:::edge
+  end
+
+  subgraph CNF_B[CNF B, ASN 65002]
+    B[Edge router B]:::edge
+  end
+
+  subgraph Cloud[Remote ASN]
+    C[Cloud or provider peers]:::cloud
+  end
+
+  subgraph Enterprise[Downstream enterprise]
+    D[Core and sites]:::enterprise
+  end
+
+  A -- eBGP --> C
+  B -- eBGP --> C
+
+  A -- iBGP / internal policy --> D
+  B -- iBGP / internal policy --> D
+
+  %% LOCAL_PREF is AS-local, so it helps inside 65001 or 65002, but does not automatically steer the other.
+  %% AS_PATH and provider-supported communities are the tools that can travel beyond the edge.
+```
+
 ## 11) Safety rails (the section that saves outages)
 
 ### Prefix-lists / route filtering
@@ -655,6 +713,32 @@ The fix is boring and effective: strict import filters (what you accept), and st
 #### Example: dual-provider internet peering (don’t become transit)
 
 In this pattern you receive routes from two upstreams, but you only ever advertise your own prefixes, and optionally a default or a small set of aggregates you explicitly intend to originate.
+
+```mermaid
+%%{init: {'theme':'neutral','flowchart':{'curve':'basis'},'themeVariables':{'fontFamily':'Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial'}}}%%
+flowchart LR
+  classDef enterprise fill:#E8F1FF,stroke:#2F6FED,stroke-width:1px,color:#0B1F44;
+  classDef provider fill:#FFF3E0,stroke:#F59E0B,stroke-width:1px,color:#3B2F00;
+  classDef edge fill:#F3E8FF,stroke:#8B5CF6,stroke-width:1px,color:#2E1065;
+
+  subgraph Upstreams[Upstreams]
+    ISP_A[ISP A]:::provider
+    ISP_B[ISP B]:::provider
+  end
+
+  Edge[Your edge router]:::edge
+  Pref[Your public prefixes]:::enterprise
+
+  ISP_A -- full routes --> Edge
+  ISP_B -- full routes --> Edge
+
+  Edge -- export: only your prefixes --> ISP_A
+  Edge -- export: only your prefixes --> ISP_B
+
+  Pref --> Edge
+
+  %% Without export filtering you can accidentally become transit (A <-> you <-> B).
+```
 
 **IOS-XE (illustrative)**
 ```ios

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -679,7 +679,7 @@ As we mentioned earlier, active/passive is often dictated by the southbound arch
 
 There are two common ways enterprises structure ASNs at the edge.
 
-### Option A: single ASN across both CNFs (one enterprise AS)
+#### Option A: single ASN across both CNFs (one enterprise AS)
 
 This is the “clean BGP” model. Both CNF routers are in the same ASN, you run eBGP to each cloud or provider peer, and you run iBGP between your CNF routers (and usually to the rest of your core).
 
@@ -687,7 +687,7 @@ It’s nice because LOCAL_PREF works exactly how you expect for choosing your ou
 
 The trade-off is that you’re now in iBGP design land (full mesh versus route reflection, and so on).
 
-### Option B: dual private ASNs (one per CNF)
+#### Option B: dual private ASNs (one per CNF)
 
 This is an operationally popular model in enterprises because it feels like “two edges”. CNF A might be ASN 65001, CNF B might be ASN 65002, each CNF peers to the cloud or provider ASN, and somewhere downstream you have to reconnect those worlds (often another BGP hop inside your enterprise).
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -32,14 +32,53 @@ BGP is also **policy-first**. It’s designed for environments where “best” 
 
 ## 2) eBGP vs iBGP (what matters at the cloud edge)
 
+There are two flavours of BGP in day-to-day designs:
+
+- **eBGP** (external BGP): between different autonomous systems.
+- **iBGP** (internal BGP): between routers *inside* the same autonomous system.
+
+If you’ve only ever "touched BGP" at an MPLS edge, you’ve almost certainly only seen **eBGP**.
+Cloud connectivity tends to drag iBGP into the conversation because you suddenly have **multiple edges** (two routers, two sites, two CNFs, two clouds) and you need consistent policy and predictable failover.
+
 ### eBGP
-(TODO: definition + why eBGP is what you typically run to providers/cloud)
+
+eBGP is what you run between your network and someone else’s.
+
+In enterprise cloud connectivity that usually means:
+- your router in a CNF peering with an **ExpressRoute** MSEE or **Direct Connect** router,
+- your router peering with an ISP,
+- your router peering with a managed MPLS provider PE.
+
+The important enterprise mental model is: **eBGP is where the AS boundary is real**.
+Across that boundary you can exchange routes, and you can *influence* the other side, but you don’t get to enforce how they do their internal routing.
 
 ### iBGP
-(TODO: definition + why iBGP design suddenly matters once you have multiple edges/CNFs)
+
+iBGP is what you run when you have multiple routers in **the same ASN** that need to share BGP-learned routes with each other.
+
+In the simplest cloud edge, you might not need iBGP at all (one router, one peering).
+As soon as you add redundancy, iBGP becomes the clean way to make your edge behave like a single logical system:
+
+- Two edge routers in the same site (active/active)
+- Two CNFs (diverse meet-me rooms)
+- Two provider circuits (separate peers)
+- Two clouds (Azure + AWS)
+
+You *can* avoid iBGP by doing weird things (like re-advertising routes between eBGP peers and hoping loop prevention doesn’t bite you), but iBGP is usually the right tool.
+
+> Note: this is where people start hearing about route reflectors.
+>
+> You don’t need them in a small design, but once you have “lots of BGP speakers”, full-mesh iBGP becomes annoying because iBGP requires every router to peer with every other router (or you introduce route reflection/confederations).
 
 ### Why you care
-(TODO)
+
+Because **your operational knobs behave differently depending on where you are**:
+
+- **LOCAL_PREF** is your best “pick the outbound exit” tool, but it’s **only meaningful inside your AS**.
+- **MED** is, at best, a **hint to a neighbour** and typically only compared in narrow conditions.
+- **AS_PATH prepending** is crude, but it’s one of the few signals that naturally propagates beyond your first-hop peer.
+
+If you understand the eBGP/iBGP boundary, the rest of BGP becomes much less mysterious.
 
 ## 3) Where enterprise engineers have seen BGP before: MPLS WAN patterns
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -8,7 +8,7 @@ tags:
   - cloud
   - azure
   - aws
-date: 2026-03-15
+date: 2026-03-16
 draft: true
 ---
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -201,6 +201,14 @@ If you strip away the product names, enterprise cloud connectivity is mostly jus
 
 That transport could be an MPLS or SD-WAN underlay, ExpressRoute or Direct Connect, or a cloud exchange in a CNF (where you have your own routers, and an L2 handoff to the peers).
 
+:::note BGP inside AWS constructs (it’s not just a hybrid edge protocol)
+BGP is no longer only about Direct Connect at the edge. AWS now has constructs where BGP drives changes inside the VPC routing domain.
+
+A good example is Amazon VPC Route Server, which can use BGP to influence route tables (including IGW route tables) for patterns like floating IP failover, or steering traffic through active/standby inspection appliances.
+
+Useful starting point: [Dynamic Routing Using Amazon VPC Route Server](https://aws.amazon.com/blogs/networking-and-content-delivery/dynamic-routing-using-amazon-vpc-route-server/)
+:::
+
 ### What’s actually peering with what?
 
 In the model we’re using for this post, your routers sit in one (or two) CNFs, you have L2 to each provider peer, and you run eBGP to Azure (ExpressRoute private peering), AWS (Direct Connect private VIF), and optionally your WAN provider(s) if you’re also aggregating MPLS or SD-WAN there.
@@ -581,9 +589,21 @@ Rather than duplicating provider tables here, I’ve [written up a comparison](c
 
 Start with the provider’s documentation for the specific connection type (DX public or private VIF, and ER private or Microsoft peering). Implement communities in code and policy with the same discipline as firewall rules, including version control, review, explicit intent, and testing. Prefer communities over “clever” AS_PATH games when the provider supports the behaviour you need.
 
+:::note Prove your resiliency, don’t just design it
+BGP failover only matters if you’ve tested it. AWS provides guidance and tooling for deliberately failing over Direct Connect virtual interfaces, which makes it easier to run proper game-days.
+
+Reference: [Testing AWS Direct Connect Resiliency with Resiliency Toolkit Failover Testing](https://aws.amazon.com/blogs/networking-and-content-delivery/testing-aws-direct-connect-resiliency-with-resiliency-toolkit-failover-testing/)
+:::
+
 ## Cloud exchange (CNF) patterns
 
 A cloud exchange is typically a **carrier neutral facility (CNF)** where you can aggregate cloud provider connectivity (ExpressRoute and Direct Connect), and WAN connectivity (MPLS and SD-WAN).
+
+:::note AWS Cloud WAN Connect and MP-BGP reality
+If you’re integrating SD-WAN or building a global enterprise WAN overlay, AWS Cloud WAN Connect is another place BGP shows up. It’s also a good reminder that modern enterprise designs often exchange IPv6 routes over MP-BGP, even when the BGP adjacency itself is IPv4.
+
+Reference: [Building a Resilient IPv6 Network with SD-WANs and AWS Cloud WAN Connect with GRE](https://aws.amazon.com/blogs/networking-and-content-delivery/building-resilient-ipv6-network-with-sd-wans-and-aws-cloud-wan-connect-with-gre/)
+:::
 
 In practice, a CNF is where enterprise networking starts to look a little bit like “real internet engineering”… except you’re doing it inside a building with cross-connects.
 
@@ -813,15 +833,13 @@ In the public internet, routing policy is often described using RPSL objects (ro
 It’s one of the reasons “who should accept what from whom” can be automated at scale.
 
 If you’ve never bumped into it before: [Routing Policy Specification Language](https://en.wikipedia.org/wiki/Routing_Policy_Specification_Language)
-
-Sidebar: a quick note on RPKI and route validation
+:::
 
 RPKI is the mechanism that lets prefix holders publish cryptographic Route Origin Authorisations (ROAs), and lets networks validate whether a route announcement is likely to be legitimate.
 
 Even if your enterprise BGP is mostly “private”, the upstreams you depend on operate in the public routing system, and the industry is increasingly treating RPKI-invalid routes as something to drop, not just something to log.
 
 AWS has a good high-level write-up of what they’re doing here, which is useful context: [How AWS is helping to secure internet routing](https://aws.amazon.com/blogs/networking-and-content-delivery/how-aws-is-helping-to-secure-internet-routing/)
-:::
 
 :::note how Azure prevents some transit scenarios
 Microsoft actively prevents certain transit-routing behaviours in the backbone (for good reasons).
@@ -874,26 +892,6 @@ Some practical differences you’ll feel are that you’re peering to a cloud se
 Public peering options exist too, and they come with sharp edges. DX public VIF and ER Microsoft peering can be great for predictable paths to public services, but they’re also where you really don’t want to accidentally export something that turns you into transit.
 
 Finally, availability patterns are “product-shaped”. You’ll often have multiple BGP sessions per circuit, dual circuits, and region and site diversity patterns. The BGP controls are the same, but the constraints around them are not.
-
-:::note BGP inside AWS constructs (it’s not just a hybrid edge protocol)
-BGP is no longer only about Direct Connect at the edge. AWS now has constructs where BGP drives changes inside the VPC routing domain.
-
-A good example is Amazon VPC Route Server, which can use BGP to influence route tables (including IGW route tables) for patterns like floating IP failover, or steering traffic through active/standby inspection appliances.
-
-Useful starting point: [Dynamic Routing Using Amazon VPC Route Server](https://aws.amazon.com/blogs/networking-and-content-delivery/dynamic-routing-using-amazon-vpc-route-server/)
-:::
-
-:::note AWS Cloud WAN Connect and MP-BGP reality
-If you’re integrating SD-WAN or building a global enterprise WAN overlay, AWS Cloud WAN Connect is another place BGP shows up. It’s also a good reminder that modern enterprise designs often exchange IPv6 routes over MP-BGP, even when the BGP adjacency itself is IPv4.
-
-Reference: [Building a Resilient IPv6 Network with SD-WANs and AWS Cloud WAN Connect with GRE](https://aws.amazon.com/blogs/networking-and-content-delivery/building-resilient-ipv6-network-with-sd-wans-and-aws-cloud-wan-connect-with-gre/)
-:::
-
-:::note prove your resiliency, don’t just design it
-BGP failover only matters if you’ve tested it. AWS provides guidance and tooling for deliberately failing over Direct Connect virtual interfaces, which makes it easier to run proper game-days.
-
-Reference: [Testing AWS Direct Connect Resiliency with Resiliency Toolkit Failover Testing](https://aws.amazon.com/blogs/networking-and-content-delivery/testing-aws-direct-connect-resiliency-with-resiliency-toolkit-failover-testing/)
-:::
 
 ### Route Server (brief pointer)
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -74,6 +74,20 @@ You *can* avoid iBGP by doing weird things (like re-advertising routes between e
 
 Because **your operational knobs behave differently depending on where you are**. LOCAL_PREF is your best “pick the outbound exit” tool, but it’s only meaningful inside your AS. MED is, at best, a hint to a neighbour, and it is typically only compared in narrow conditions. AS_PATH prepending is crude, but it’s one of the few signals that naturally propagates beyond your first-hop peer.
 
+> Sidebar: iBGP, eBGP, and where they sit in the route selection hierarchy
+>
+> There are two different “selection” processes people conflate.
+>
+> One is the BGP best-path algorithm, which chooses one BGP path over another.
+>
+> The other is the router’s global route selection behaviour, where different protocols all claim they can reach the same destination prefix, and the router has to choose which one makes it into the forwarding table.
+>
+> On Cisco platforms, the default administrative distances reflect a common design assumption: BGP speakers are at the edge. eBGP-learned routes are therefore treated as a strong signal for external reachability, while iBGP-learned routes are treated as much less preferable than IGP-learned routes.
+>
+> The rationale is pragmatic. If you’ve already learned the route from the IGP, it’s often “closer” and more efficient to follow that IGP path than to follow an iBGP hop-count that might simply be reflecting policy, or topology you don’t want to traverse.
+>
+> The punchline is that if you redistribute between protocols, or if you run BGP deep in the network, you should understand how administrative distance interacts with BGP, and consider whether you need to tune it for your design.
+
 If you understand the eBGP/iBGP boundary, the rest of BGP becomes much less mysterious.
 
 ## 3) Where enterprise engineers have seen BGP before: MPLS WAN patterns

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -87,6 +87,16 @@ Because **your operational knobs behave differently depending on where you are**
 > The rationale is pragmatic. If you’ve already learned the route from the IGP, it’s often “closer” and more efficient to follow that IGP path than to follow an iBGP hop-count that might simply be reflecting policy, or topology you don’t want to traverse.
 >
 > The punchline is that if you redistribute between protocols, or if you run BGP deep in the network, you should understand how administrative distance interacts with BGP, and consider whether you need to tune it for your design.
+>
+> Sidebar: iBGP and eBGP multipath (and why you suddenly care in cloud)
+>
+> BGP is often taught as “pick one best path”, which is true for what it advertises, but not always true for what it forwards.
+>
+> Most platforms can install multiple equal-cost BGP paths for the same prefix (multipath) and then forward over them using ECMP. Whether paths are considered “equal enough” depends on the platform and config, but the important point is that multipath is an explicit design choice.
+>
+> This matters in cloud connectivity because active/active circuit pairs often rely on it. ExpressRoute in particular is commonly delivered as redundant circuit pairs, and many designs expect to use both links in steady state. Without multipath, you can easily end up with “one link hot, one link cold”, even though you paid for both.
+>
+> If you need symmetric flows through stateful appliances, you might still choose active/passive, but if you are aiming for active/active, make sure you understand how your platform handles eBGP multipath, iBGP multipath, and the tie-breaks that decide which paths qualify.
 
 If you understand the eBGP/iBGP boundary, the rest of BGP becomes much less mysterious.
 

--- a/blog/bgp-for-enterprise-cloud-connectivity.md
+++ b/blog/bgp-for-enterprise-cloud-connectivity.md
@@ -234,6 +234,8 @@ In practice, for enterprise connectivity, you can think in three buckets: things
 > If you want the rationale for why prefix length wins before any BGP attribute, and why we shouldn’t abuse it, this post is the best explanation I’ve written: https://www.simonpainter.com/longest-prefix-matching/
 >
 > Vendor note: the exact tie-break order differs slightly between implementations, and there are knobs to change it. Junos has a good write-up here, including its default MED comparison behaviour and the options that alter it: https://www.juniper.net/documentation/us/en/software/junos/vpn-l2/bgp/topics/concept/routing-protocols-address-representation.html
+>
+> Cisco has a canonical write-up too (and it’s a good reminder that Cisco has router-local attributes like WEIGHT that don’t exist everywhere): https://www.cisco.com/c/en/us/support/docs/ip/border-gateway-protocol-bgp/13753-25.html
 
 ### The three attributes you’ll use constantly
 


### PR DESCRIPTION
## What this PR is
Draft blog post: **“BGP for Enterprise Cloud Connectivity”** — a practical, enterprise‑leaning intro to using BGP as the routing control plane for hybrid / multi‑cloud connectivity.

## What’s included
- New article: `blog/bgp-for-enterprise-cloud-connectivity.md`
- Covers:
  - Why BGP shows up in real enterprise WAN / cloud designs (and why it’s not just “ISP stuff”)
  - Mental model: paths, attributes, policy, convergence
  - eBGP vs iBGP (and the common enterprise patterns around them)
  - How BGP fits with cloud connectivity primitives (VPN/ER/Direct Connect/Interconnect)
  - **Azure accuracy pass**: specific limits and recommended timers (from Copilot fact‑check)

## Status
- **WIP**: content is usable but still being tightened (flow, examples, diagrams/snippets).

## Reviewer notes / nits to address
- Standardise **JunOS/Junos** casing
- Confirm excerpt marker convention: `<!-- truncate -->` vs `<!--truncate-->`
- Markdown blockquote spacing in acronym callout (`> **PE** …`)

## How to review
- Read end‑to‑end for narrative/structure first
- Then sanity‑check the technical claims (esp. Azure sections + timer/limit values)
