### PR TITLE
New post: DNS over QUIC: What Quad9's DoQ support means for enterprise DNS

### DIFF
--- a/blog/dns-dot-doh-doq.md
+++ b/blog/dns-dot-doh-doq.md
@@ -157,7 +157,7 @@ A validating resolver checks that signature against the zone's public key (in th
 
 DNSSEC uses a chain of trust. The `.com` nameservers sign the DNSKEY records for `example.com`. Root nameservers sign the DNSKEY records for `.com`. A resolver that trusts the root key—which is published and well-known—can validate the entire chain from root to leaf. Compromise of a recursive resolver can't produce a valid RRSIG without the zone's private key.
 
-That's the property you want in an enterprise. If your internal resolver is validating DNSSEC, a DNS poisoning attack that redirects `payments.internal` to a malicious IP will fail because it can't produce a valid signature. Encryption of the query doesn't give you this—an encrypted query to a compromised resolver just gets you a confidential wrong answer.
+That's the property you want in an enterprise. If your resolver is validating DNSSEC, a DNS poisoning attack that redirects a signed name such as `example.com` to a malicious IP will fail because it can't produce a valid signature. For internal names such as `payments.internal`, that same protection only applies if the internal zone is DNSSEC-signed and your resolver has a trust anchor for it. Encryption of the query doesn't give you this—an encrypted query to a compromised resolver just gets you a confidential wrong answer.
 
 DNSSEC is protocol-agnostic. It works over plain DNS/UDP, DoT, DoH, or DoQ. The signature is in the response, not the transport. You can have DNSSEC validation without any encryption, and you can have encrypted DNS without any DNSSEC. They're independent.
 

--- a/blog/dns-dot-doh-doq.md
+++ b/blog/dns-dot-doh-doq.md
@@ -1,6 +1,6 @@
 ---
 
-title: "DNS over QUIC: What Quad9's DoQ support means for enterprise DNS"
+title: "Quad9 now supports DoQ along with DoH3""
 authors: simonpainter
 tags:
   - dns
@@ -12,9 +12,9 @@ date: 2026-04-06
 
 ---
 
-The answer may indeed be 'not a lot', but I thought it was worth a clickbait headline from time to time. In March 2026, Quad9 announced support for DNS over QUIC (DoQ) alongside DoH3 on their public resolver network. That's the same month Microsoft's DoH support for Windows Server DNS moved out of preview. Two announcements in the same month, both about encrypted DNS, and they point in different directions.
+In March 2026, [Quad9 announced support for DNS over QUIC (DoQ) alongside DoH3 on their public resolver network](https://quad9.net/news/blog/quad9-enables-dns-over-http-3-and-dns-over-quic/). That's the same month Microsoft's DoH support for Windows Server DNS moved out of preview. Two announcements in the same month, both about encrypted DNS, and they point in different directions.
 
-Microsoft's move continues the push toward DoH—encryption that hides in plain sight on port 443. Quad9's move adds DoQ, which offers better latency than DoT but keeps the port 853 visibility that enterprises actually want. Together they prompt a question I don't think the industry has properly answered yet: are we encrypting DNS for privacy, or for security? Because the answer changes everything about which protocol you should reach for.
+Microsoft's move continues the push toward DoH—encryption that hides in plain sight on port 443. Quad9's move adds DoQ, which offers better latency than DoT but keeps the port 853 visibility that enterprises actually want. Together they prompt a question I don't think the industry has properly answered yet: are we encrypting DNS for privacy, or for security? Because the answer changes everything about which protocol you should reach for. In this post I'll largely ignore DOH3, which is DoH over HTTP/3. It's HTTP/3 and that's about as exciting as it gets, otherwise it's the same story as DoH over HTTP/2.
 
 This post builds on my earlier posts on [encrypted DNS governance](encrypted-dns.md) and [SVCB/HTTPS records](svcb-https-records.md). I'm not going to re-cover the wire format or the DoT vs DoH comparison—read those first if you need the background. This is about DoQ specifically, what QUIC brings to DNS, and why I think the enterprise conversation about encrypted DNS is asking the wrong question.
 
@@ -22,14 +22,15 @@ This post builds on my earlier posts on [encrypted DNS governance](encrypted-dns
 
 ## What QUIC Actually Is
 
-Before talking about DoQ, it's worth being clear about what QUIC is—because it's not just "faster TCP."
+Before talking about DoQ, it's worth being clear about what QUIC is—because it's not just "faster than TCP."
 
 QUIC is a transport protocol designed from scratch with encryption as a first-class requirement, not an optional layer. It runs over UDP but provides the reliability, ordering, and congestion control you'd expect from TCP. The key distinction is that TLS isn't bolted on top of QUIC the way it is with TCP—the handshake is integrated. You can't have an unencrypted QUIC connection. Encryption is structural.
 
-
 That integration matters for DNS because it collapses two separate negotiations—the TCP handshake and the TLS handshake—into one. TLS 1.3 over TCP costs 2 round trips before you can send application data. QUIC costs 1. For a protocol where every millisecond of the lookup adds to page load time, that's meaningful.
 
-QUIC also solves a problem that's plagued multiplexed protocols running over TCP: head-of-line blocking. When TCP loses a packet, everything queued behind it stalls until retransmission succeeds. HTTP/2 over TCP has this problem—you can have 50 requests multiplexed on one connection, but a single lost packet freezes all of them. QUIC handles loss at the stream level. If stream 5 loses a packet, streams 7 and 9 keep moving.
+QUIC also solves a problem that's plagued multiplexed protocols running over TCP: head-of-line blocking. When TCP loses a packet, everything queued behind it stalls until retransmission succeeds. HTTP/2 over TCP has this problem—you can have 50 requests multiplexed on one connection, but a single lost packet freezes all of them. QUIC handles loss at the stream level. If stream 5 loses a packet, streams 7 and 9 keep moving. This is a really big deal and addresses one of the biggest performance issues with DoH over HTTP/2 and DoT.
+
+DNS is built on UDP for a reason, it's designed to be fast and low latency and for the request and response to be independent and non blocking. If the problem is the lack of encryption, and that's hardly a given, then DoQ is the better solution than DoH and DoT because it preserves the performance characteristics of UDP while adding encryption.
 
 ## DoQ: DNS-over-TCP's Logic, QUIC's Performance
 
@@ -37,36 +38,15 @@ QUIC also solves a problem that's plagued multiplexed protocols running over TCP
 
 Each DNS query/response pair gets its own bidirectional QUIC stream. The client's first query goes on stream 0, second on stream 4, third on stream 8. Because each is independent, responses can arrive out of order with no head-of-line blocking—the stream ID tells you which query a response belongs to.
 
-RFC 9250 makes one notable departure from conventional DNS: Message IDs must be set to zero on DoQ connections. The stream handles query/response correlation, so the 16-bit ID field that DNS has used since 1987 is redundant. Proxies that translate DoQ to DoT or UDP have to synthesise a real Message ID—something to watch for in implementations.
-
-```mermaid
-sequenceDiagram
-    participant C as Client
-    participant R as Resolver
-
-    Note over C,R: Cold start: DoT vs DoQ
-    
-    Note over C,R: DoT needs TCP + TLS (2-3 RTT)
-    C->>R: TCP SYN
-    R->>C: TCP SYN-ACK
-    C->>R: TCP ACK + TLS ClientHello
-    R->>C: TLS ServerHello + Certificate
-    C->>R: TLS Finished + DNS Query (stream)
-    R->>C: DNS Response
-
-    Note over C,R: DoQ needs QUIC Initial only (1-2 RTT)
-    C->>R: QUIC Initial (TLS ClientHello embedded)
-    R->>C: QUIC Handshake (TLS ServerHello + DNS Response)
-```
+RFC 9250 makes one notable departure from conventional DNS: Message IDs must be set to zero on DoQ connections. The stream handles query/response correlation, so the 16-bit ID field that DNS has used since 1987 is redundant. Proxies that translate DoQ to DoT or UDP have to synthesise a real Message ID, something to watch for in implementations.
 
 The 0-RTT resumption story is where DoQ really separates itself from DoT. When a client has previously connected to a DoQ resolver, it stores a session token. On the next connection, it can send encrypted DNS data in the very first packet—before the server has responded at all. The resolver processes the query and the handshake simultaneously. For mobile clients that cycle through network connections frequently, that's not a theoretical win. It's a real reduction in lookup latency at exactly the moment users notice it most—when an app opens after switching from WiFi to cellular.
 
-
 ## What Quad9's Announcement Actually Means
 
-Quad9 isn't the first public resolver to support DoQ—AdGuard and NextDNS got there earlier—but Quad9 is the first major infrastructure-grade resolver to do so. Quad9 operates 250+ PoPs globally, partners with Shadowserver for threat intelligence, and is a common choice for enterprises that want a privacy-respecting public resolver without Google or Cloudflare in the supply chain.
+Quad9 isn't the first public resolver to support DoQ, AdGuard and NextDNS got there earlier, but Quad9 is the first major infrastructure-grade resolver to do so. Quad9 operates 250+ PoPs globally, partners with Shadowserver for threat intelligence, and is a common choice for enterprises that want a privacy-respecting public resolver without Google or Cloudflare in the supply chain.
 
-The announcement also included DoH3—DoH carried over HTTP/3, which runs on QUIC. That's the best-of-both-worlds option if you want DoH's port 443 invisibility alongside QUIC's performance characteristics. Modern browsers that support HTTP/3 will upgrade from DoH/HTTP/2 to DoH3 automatically via Alt-Svc headers.
+The announcement also included DoH3, DoH carried over HTTP/3, which runs on QUIC. That's the best-of-both-worlds option if you want DoH's port 443 invisibility alongside QUIC's performance characteristics. Modern browsers that support HTTP/3 will upgrade from DoH/HTTP/2 to DoH3 automatically via Alt-Svc headers.
 
 What changes practically? Two things.
 
@@ -87,25 +67,17 @@ timeline
     2026 : DoQ reaches production scale with Quad9 and DoH3
 ```
 
+My worry is that the industry will treat DoQ as the last to the party and not adopt it as the best option for enterprise encypted DNS. Already we've seen Microsoft opt for DoH over DoT; one of the product managers told me they 'had to do one first' and DoH was the one supported on the client end. It would be good to see some joined up thinking with the Windows client and the DNS server teams making an intentional choice to support the protocol offering the best performance and security properites for enterpise use.
+
+I get why 1.1.1.1, 8.8.8.8, 9.9.9.9 and all the other public resolvers have been quick to add DoH support. It's the easiest one to market to end users because it melts into the background of https traffic and is hard to spot, hard to police, and hard to sniff. For privacy conscious end users, DoH is the obvious choice even though it is an abomination of a protocol from a performance, management, and security perspective.
+
+For enterpise the choices are different. All the reasons a privacy conscious end user would want DoH are the same reasons an enterprise would absolutely not want it. DoH is a nightmare for enterprise visibility and governance. DoT is better, but the TCP handshake and TLS handshake overheads are a real problem for high-churn environments. DoQ is the best of both worlds: encryption without lower performance cost, and port 853 visibility for enterprise governance.
+
 The choice of protocol has always been about more than performance. Where you run your DNS and who you need to trust shapes which protocol makes sense.
 
 DoH runs on port 443 and is indistinguishable from ordinary HTTPS. That's by design—it protects privacy from network observers including enterprise firewalls. As I covered in [my first encrypted DNS post](encrypted-dns.md), this is exactly what breaks FortiGate wildcard FQDN objects and circumvents DNS-based threat intelligence. DoH prioritises user confidentiality over organisational visibility.
 
-DoT and DoQ both run on port 853 and are identifiable as encrypted DNS without any decryption. A firewall can see the traffic, measure its volume, and block or allow specific resolver IPs. Enterprises that want encrypted DNS without losing observability have always been pushed toward DoT. Now they have DoQ as an alternative with better connection setup characteristics.
-
 The meaningful comparison for enterprise architects isn't DoT vs DoH any more—it's DoT vs DoQ, with DoH as the external-facing option for users on untrusted networks.
-
-| Aspect | DoT | DoQ | DoH |
-|--------|-----|-----|-----|
-| Port | 853 | 853 | 443 |
-| Transport | TCP + TLS | QUIC (TLS integrated) | TCP + TLS + HTTP/2 |
-| Cold start RTT | 2-3 | 1-2 | 2-3 |
-| 0-RTT resumption | No | Yes | No |
-| Head-of-line blocking | Yes (TCP) | No | Partial (HTTP/2) |
-| Identifiable as DNS | Yes | Yes | No |
-| Enterprise visibility | Yes | Yes | Needs interception |
-| Tooling maturity | High | Early | Medium |
-
 
 ## The Question Nobody's Asking
 
@@ -128,7 +100,7 @@ DNSSEC ([RFC 4033](https://datatracker.ietf.org/doc/html/rfc4033), [RFC 4034](ht
 
 Zone operators sign their DNS records with a private key. The signature arrives in the response as an RRSIG record alongside the real data:
 
-```
+```dns
 example.com. 3600 IN A 93.184.216.34
 example.com. 3600 IN RRSIG A 8 2 3600 20260501000000 20260401000000 (
     12345 example.com. <base64-encoded-signature> )
@@ -146,27 +118,17 @@ DNSSEC is protocol-agnostic. It works over plain DNS/UDP, DoT, DoH, or DoQ. The 
 
 Roughly 60-65% of domain names are DNSSEC-signed globally. Most TLDs are signed. The root is signed. Cloudflare, Google, Quad9, and other major resolver operators validate DNSSEC by default.
 
-But most enterprises don't run DNSSEC validation on their internal resolvers. They've deployed split-horizon DNS for internal zones. They've spent effort on encrypted DNS transport. They've blocked port 853 outbound. And they've left the door open to response tampering because their recursive resolver doesn't validate signatures.
+But a lot of enterprises don't run DNSSEC validation on their internal resolvers. They've deployed split-horizon DNS for internal zones. They've spent effort on encrypted DNS transport. They've blocked port 853 outbound. And they've left the door open to response tampering because their recursive resolver doesn't validate signatures.
 
-The DNSSEC operational overhead is real—key rotation, larger response sizes due to RRSIG records, occasional validation failures that are painful to debug. But that overhead is lower than deploying and maintaining TLS interception infrastructure to inspect DoH traffic.
+There's no excuse for this from a tooling perspective. [Windows DNS Server has supported DNSSEC since Windows Server 2012](https://learn.microsoft.com/en-us/windows-server/networking/dns/dnssec-overview)—that's over a decade of availability. BIND has supported it for longer. The feature is there; it just hasn't been prioritised.
 
+The DNSSEC operational overhead is real: key rotation, larger response sizes due to RRSIG records, occasional validation failures that are painful to debug. But that overhead is lower than deploying and maintaining TLS interception infrastructure to inspect DoH traffic.
 
 ## Authentication vs Confidentiality in Practice
 
 Consider the threat models honestly.
 
 An enterprise DNS resolver sits on your network, answering queries from your clients. The path from client to resolver is on infrastructure you control. The path from resolver to upstream forwarder might cross ISP networks. The path from forwarder to authoritative nameserver crosses the public internet.
-
-```mermaid
-flowchart TD
-    A[Employee Client] -->|"Your network\nDNSSEC validates responses"| B["Internal Recursive Resolver"]
-    B -->|"DoT to public resolver\nconfidentiality on untrusted path"| C["Public Resolver e.g. Quad9\nvalidates DNSSEC"]
-    C -->|"DNSSEC chain of trust"| D["Authoritative Nameservers\nDNSSEC-signed zones"]
-    
-    style B fill:#d4edda
-    style C fill:#d4edda
-    style D fill:#d4edda
-```
 
 On the internal hop, you control the network. DNSSEC validation at your resolver means tampered responses are rejected. You don't need to encrypt this hop for security reasons—and encrypting it removes the query visibility you need for threat detection.
 

--- a/blog/dns-dot-doh-doq.md
+++ b/blog/dns-dot-doh-doq.md
@@ -1,6 +1,6 @@
 ---
 
-title: "Quad9 now supports DoQ along with DoH3""
+title: "Quad9 now supports DoQ along with DoH3"
 authors: simonpainter
 tags:
   - dns
@@ -14,7 +14,7 @@ date: 2026-04-06
 
 In March 2026, [Quad9 announced support for DNS over QUIC (DoQ) alongside DoH3 on their public resolver network](https://quad9.net/news/blog/quad9-enables-dns-over-http-3-and-dns-over-quic/). That's the same month Microsoft's DoH support for Windows Server DNS moved out of preview. Two announcements in the same month, both about encrypted DNS, and they point in different directions.
 
-Microsoft's move continues the push toward DoH—encryption that hides in plain sight on port 443. Quad9's move adds DoQ, which offers better latency than DoT but keeps the port 853 visibility that enterprises actually want. Together they prompt a question I don't think the industry has properly answered yet: are we encrypting DNS for privacy, or for security? Because the answer changes everything about which protocol you should reach for. In this post I'll largely ignore DOH3, which is DoH over HTTP/3. It's HTTP/3 and that's about as exciting as it gets, otherwise it's the same story as DoH over HTTP/2.
+Microsoft's move continues the push toward DoH—encryption that hides in plain sight on port 443. Quad9's move adds DoQ, which offers better latency than DoT but keeps the port 853 visibility that enterprises actually want. Together they prompt a question I don't think the industry has properly answered yet: are we encrypting DNS for privacy, or for security? Because the answer changes everything about which protocol you should reach for. In this post I'll largely ignore DoH3, which is DoH over HTTP/3. It's HTTP/3 and that's about as exciting as it gets, otherwise it's the same story as DoH over HTTP/2.
 
 This post builds on my earlier posts on [encrypted DNS governance](encrypted-dns.md) and [SVCB/HTTPS records](svcb-https-records.md). I'm not going to re-cover the wire format or the DoT vs DoH comparison—read those first if you need the background. This is about DoQ specifically, what QUIC brings to DNS, and why I think the enterprise conversation about encrypted DNS is asking the wrong question.
 
@@ -30,7 +30,7 @@ That integration matters for DNS because it collapses two separate negotiations�
 
 QUIC also solves a problem that's plagued multiplexed protocols running over TCP: head-of-line blocking. When TCP loses a packet, everything queued behind it stalls until retransmission succeeds. HTTP/2 over TCP has this problem—you can have 50 requests multiplexed on one connection, but a single lost packet freezes all of them. QUIC handles loss at the stream level. If stream 5 loses a packet, streams 7 and 9 keep moving. This is a really big deal and addresses one of the biggest performance issues with DoH over HTTP/2 and DoT.
 
-DNS is built on UDP for a reason, it's designed to be fast and low latency and for the request and response to be independent and non blocking. If the problem is the lack of encryption, and that's hardly a given, then DoQ is the better solution than DoH and DoT because it preserves the performance characteristics of UDP while adding encryption.
+DNS is built on UDP for a reason, it's designed to be fast and low latency and for the request and response to be independent and non-blocking. If the problem is the lack of encryption, and that's hardly a given, then DoQ is the better solution than DoH and DoT because it preserves the performance characteristics of UDP while adding encryption.
 
 ## DoQ: DNS-over-TCP's Logic, QUIC's Performance
 
@@ -67,11 +67,11 @@ timeline
     2026 : DoQ reaches production scale with Quad9 and DoH3
 ```
 
-My worry is that the industry will treat DoQ as the last to the party and not adopt it as the best option for enterprise encypted DNS. Already we've seen Microsoft opt for DoH over DoT; one of the product managers told me they 'had to do one first' and DoH was the one supported on the client end. It would be good to see some joined up thinking with the Windows client and the DNS server teams making an intentional choice to support the protocol offering the best performance and security properites for enterpise use.
+My worry is that the industry will treat DoQ as late to the party and not adopt it as the best option for enterprise encrypted DNS. Already we've seen Microsoft opt for DoH over DoT; one of the product managers told me they 'had to do one first' and DoH was the one supported on the client end. It would be good to see some joined up thinking with the Windows client and the DNS server teams making an intentional choice to support the protocol offering the best performance and security properties for enterprise use.
 
 I get why 1.1.1.1, 8.8.8.8, 9.9.9.9 and all the other public resolvers have been quick to add DoH support. It's the easiest one to market to end users because it melts into the background of https traffic and is hard to spot, hard to police, and hard to sniff. For privacy conscious end users, DoH is the obvious choice even though it is an abomination of a protocol from a performance, management, and security perspective.
 
-For enterpise the choices are different. All the reasons a privacy conscious end user would want DoH are the same reasons an enterprise would absolutely not want it. DoH is a nightmare for enterprise visibility and governance. DoT is better, but the TCP handshake and TLS handshake overheads are a real problem for high-churn environments. DoQ is the best of both worlds: encryption without lower performance cost, and port 853 visibility for enterprise governance.
+For enterprise the choices are different. All the reasons a privacy conscious end user would want DoH are the same reasons an enterprise would absolutely not want it. DoH is a nightmare for enterprise visibility and governance. DoT is better, but the TCP handshake and TLS handshake overheads are a real problem for high-churn environments. DoQ is the best of both worlds: encryption with a lower performance cost, and port 853 visibility for enterprise governance.
 
 The choice of protocol has always been about more than performance. Where you run your DNS and who you need to trust shapes which protocol makes sense.
 
@@ -120,7 +120,7 @@ Roughly 60-65% of domain names are DNSSEC-signed globally. Most TLDs are signed.
 
 But a lot of enterprises don't run DNSSEC validation on their internal resolvers. They've deployed split-horizon DNS for internal zones. They've spent effort on encrypted DNS transport. They've blocked port 853 outbound. And they've left the door open to response tampering because their recursive resolver doesn't validate signatures.
 
-There's no excuse for this from a tooling perspective. [Windows DNS Server has supported DNSSEC since Windows Server 2012](https://learn.microsoft.com/en-us/windows-server/networking/dns/dnssec-overview)—that's over a decade of availability. BIND has supported it for longer. The feature is there; it just hasn't been prioritised.
+There's no excuse for this from a tooling perspective. [Windows DNS Server has supported DNSSEC since Windows Server 2012](https://learn.microsoft.com/en-us/windows-server/networking/dns/dnssec-overview). BIND has supported it for longer. The feature is there; it just hasn't been prioritised.
 
 The DNSSEC operational overhead is real: key rotation, larger response sizes due to RRSIG records, occasional validation failures that are painful to debug. But that overhead is lower than deploying and maintaining TLS interception infrastructure to inspect DoH traffic.
 
@@ -140,8 +140,7 @@ The result: DNSSEC validation on your recursive resolver + DoT or DoQ on the ups
 
 Deploying DoH internally gives you confidentiality on a hop you already control, removes the query visibility you need, and still leaves you vulnerable to response tampering if your resolver isn't validating DNSSEC.
 
-I'd take DNSSEC validation on a plaintext resolver over DoH without DNSSEC validation, every time, for an internal enterprise deployment.
-
+I'd take DNSSEC validation on a plaintext resolver over DoH without DNSSEC validation, every time, for an enterprise deployment.
 
 ## What DoQ Changes for Enterprises
 
@@ -155,13 +154,10 @@ DoQ also has better characteristics for zone transfers. Zone content can be larg
 
 The tooling maturity gap is real—DoQ monitoring and inspection tools are considerably less developed than DoT equivalents. If you're considering DoQ for enterprise internal use today, factor in that your observability tooling may need to catch up.
 
-
 ## The Practical Upshot
 
-If you haven't already, the most impactful thing you can do for your enterprise DNS security posture isn't deploying encrypted transports. It's enabling DNSSEC validation on your internal recursive resolvers. Both Windows Server DNS (2019+) and BIND support it with minimal configuration change. Your upstream resolvers (Quad9, Cloudflare, Google) already validate—make sure your internal resolvers do too.
+If you haven't already, the most impactful thing you can do for your enterprise DNS security posture isn't deploying encrypted transports. It's enabling DNSSEC validation on your internal recursive resolvers. Both Windows Server DNS and BIND support it with minimal configuration change. Your upstream resolvers (Quad9, Cloudflare, Google) already validate so make sure your internal resolvers do too.
 
-Once that's in place, use DoT on the upstream forwarder hop—from your internal resolver to your public DNS provider. This gives confidentiality where the network is untrusted and maintains visibility on the internal network.
+Once that's in place, use DoT or DoQ on the upstream forwarder hop, from your internal resolver to your public DNS provider. This gives confidentiality where the network is untrusted and maintains visibility on the internal network.
 
-DoH belongs at the edge, not inside the perimeter. For users on untrusted networks—remote workers, mobile devices away from corporate infrastructure—DoH provides confidentiality from their local network observer. Inside your perimeter, it removes visibility for no additional security gain over DNSSEC + DoT.
-
-DoQ is worth watching for the upstream forwarder role, especially if you're running cloud-native or serverless workloads where connection churn is high. Quad9's production deployment means there's now a well-tested target to build against. Expect tooling to mature over the next 12-18 months.
+DoH belongs outside the enterprise, not inside the perimeter. For users on untrusted networks such as remote workers, or mobile devices away from corporate infrastructure, DoH provides confidentiality from their local network observer. Inside your perimeter, it removes visibility for no additional security gain over DNSSEC + DoT/DoQ.

--- a/blog/dns-dot-doh-doq.md
+++ b/blog/dns-dot-doh-doq.md
@@ -1,0 +1,488 @@
+---
+
+title: "DNS, DoT, DoH, and DoQ: The Evolution of Encrypted DNS"
+authors: simonpainter
+tags:
+  - dns
+  - security
+  - networks
+  - architecture
+  - educational
+date: 2026-04-06
+
+---
+
+Back in February, Microsoft quietly shipped DoH support on Windows Server DNS. In March, Quad9 announced DoQ (DNS over QUIC) alongside DoH3 on their resolver network. These announcements mark a quiet inflection point in how DNS moves across the wire. The protocol landscape has evolved from a single option—unencrypted DNS over UDP—to a real choice between encryption methods, each with different performance characteristics, operational visibility, and security trade-offs.
+
+This article compares four DNS transport models: plain DNS (the baseline), DNS over TLS (DoT), DNS over HTTPS (DoH), and DNS over QUIC (DoQ). I've already written about [encrypted DNS governance](https://www.simonpainter.com/encrypted-dns) and [SVCB/HTTPS records](https://www.simonpainter.com/svcb-https-records) from the enterprise perspective. This piece steps back to examine the protocols themselves—their design philosophy, their wire-level characteristics, and where each fits in modern infrastructure.
+
+The comparison isn't about which protocol is "best." It's about understanding what each protocol was designed to do, what it trades off to get there, and when those trade-offs actually matter in practice.
+
+<!-- truncate -->
+
+---
+
+## Plain DNS: The Baseline
+
+Before encryption arrived, DNS was simple. A client sent a query over UDP port 53, the server sent back a response, and that was the transaction. Fast, stateless, and transparent to anyone on the network path.
+
+### The Wire Format
+
+I covered the DNS message format in detail in my [encrypted DNS post](https://www.simonpainter.com/encrypted-dns), but the headline is: the message itself is 12 bytes of fixed header followed by variable-length question, answer, authority, and additional sections. Most A record queries fit in about 33 bytes total. The response to `example.com?` returning a single A record is about 45 bytes.
+
+The message goes straight into a UDP datagram with no framing overhead. Port 53. No encryption. No authentication. The resolver has no way to know if the query came from the client it thought it did, and the client has no way to know if the response came from the resolver it asked.
+
+### Why It Still Dominates
+
+Despite everything that's come after, plain DNS remains the dominant transport for most queries. It's fast, simple, and works everywhere.
+
+One transaction: client sends 33 bytes on port 53, receives 45 bytes back. Sub-200ms wall-clock time on most networks. Compare that to encrypted transports which need handshakes, TLS negotiation, and connection setup. For a single query, encrypted DNS is slower. For sustained traffic, it catches up because the handshake cost is spread across many queries.
+
+### The Attack Surface
+
+Unencrypted DNS is transparent to any observer on the path. Your ISP sees what domains you resolve. Your corporate firewall sees what your users query. Your government can mandate that ISPs redirect DNS traffic to state-monitored resolvers—and many do. An attacker can forge responses, inject malware-hosting IPs into lookups, or run DNS exfiltration channels for command and control.
+
+None of this is theoretical. I built a [fully functional API proxy on DNS TXT records](https://www.simonpainter.com/dns-api-proxy) in an afternoon. Unencrypted DNS is a covert channel waiting to be exploited.
+
+RFC 9076 (DNS Privacy Considerations) documents the threat model in detail. The security community has been clear about the problem for years. The response has been encryption—but the question has always been: which encryption method?
+
+---
+
+## DNS over TLS (DoT): Encryption Without Overhead
+
+[RFC 7858](https://datatracker.ietf.org/doc/html/rfc7858) defines DoT. The design is straightforward: take DNS-over-TCP (which adds a 2-byte length prefix to handle stream framing), wrap it in TLS, and run it on port 853.
+
+### The Wire Format
+
+```
+TCP Connection (3-way handshake)
+ └── TLS Handshake (typically 1-2 round trips with TLS 1.3)
+ └── [2-byte length field][DNS wire message]
+     [2-byte length field][DNS wire message]
+     [2-byte length field][DNS wire message]
+```
+
+The DNS message doesn't change. The length field from TCP-DNS stays. TLS encrypts everything inside the session. The query and response—the domain names being resolved—are hidden. But the metadata isn't: port 853 traffic is visible, along with its volume and timing.
+
+### Built for TCP
+
+TCP adds overhead. The three-way handshake costs 1.5 round trips before any data arrives. TLS adds another round trip (or two with older versions, one with TLS 1.3). By the time the client is ready to send a query, 100+ milliseconds might have passed on a distant connection.
+
+Once connected, though, TCP is efficient. The client can pipeline queries—send multiple queries without waiting for each response, with the transaction ID in the DNS header matching answers to questions. Modern TCP handles loss recovery well for a sustained stream of queries.
+
+DoT is designed to be long-lived. The client opens a connection, sends multiple queries over it, and keeps it alive across transactions. Most DoT implementations configure idle timeouts of 60 seconds or more—the connection is an asset worth keeping warm.
+
+The trade-off is that establishing a new connection is expensive. For mobile clients or those with sporadic query patterns, DoT's connection cost hits harder than UDP's stateless model.
+
+### Operational Visibility
+
+DoT traffic is identifiable by port. A firewall can see port 853 in use without decrypting anything. That's both a strength and a weakness.
+
+The strength: if you want to enforce encrypted DNS while monitoring which resolvers clients reach, DoT is visible. You can count queries by measuring packet rate and block or allow specific resolver IPs without TLS interception.
+
+The weakness: port 853 is identifiable and blockable. A network that wants to prevent encrypted DNS can simply block port 853 outbound. For users in restrictive environments, the visibility that makes DoT operationally clean for administrators makes it fragile for privacy.
+
+### When to Use DoT
+
+DoT is the right choice for enterprise stub-to-recursive deployments—internal clients using internal resolvers. It's also well-suited to any scenario where port 853 visibility is acceptable or desirable. If you operate your own network and want encrypted DNS without losing observability, DoT is the straightforward option.
+
+For public resolver deployments where users might be on hostile networks, DoT is less appealing. Blocking it is trivial.
+
+---
+
+## DNS over HTTPS (DoH): Encryption by Stealth
+
+[RFC 8484](https://datatracker.ietf.org/doc/html/rfc8484) takes a different philosophy from DoT. Rather than creating a dedicated transport, DoH encapsulates DNS inside HTTP/2 (or HTTP/3) over standard HTTPS on port 443.
+
+### The Wire Format
+
+GET method:
+```
+GET /dns-query?dns=AAABAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB HTTP/2
+Host: dns.example.com
+Accept: application/dns-message
+```
+
+The DNS message is base64url-encoded as a query parameter. Simple, cacheable by intermediaries, but with roughly 33% overhead from base64 encoding.
+
+POST method:
+```
+POST /dns-query HTTP/2
+Host: dns.example.com
+Content-Type: application/dns-message
+Content-Length: 33
+
+[raw DNS wire message]
+```
+
+The DNS message goes as the binary request body. No encoding overhead, but responses aren't cacheable by default.
+
+### Why HTTP/2?
+
+DoH runs over HTTP/2, and that matters. HTTP/2 provides stream multiplexing—multiple DNS queries and responses can be in-flight at once on a single TLS connection, identified by stream IDs. This avoids head-of-line blocking where a single lost packet on TCP would stall all subsequent queries. HTTP/2 headers are compressed with HPACK, reducing per-query overhead for repeated headers.
+
+The persistent connection model is the same as DoT: open once, send multiple queries. But because DoH is HTTP, CDNs can cache GET responses, and intermediate proxies can inspect DoH traffic if TLS is intercepted.
+
+### Operational Invisibility
+
+This is where DoH changes things. DoH traffic is structurally identical to ordinary HTTPS web traffic. A firewall sees port 443, which it allows for web browsing. The HTTP/2 headers show requests to `/dns-query`, but those look like any REST API call. Without TLS interception, DoH is indistinguishable from normal web traffic.
+
+That's intentional. It's why DoH became the default in Chrome, Firefox, and increasingly in operating systems. A user on a network that monitors DNS can't block DoH without also decrypting HTTPS—and decrypting HTTPS at scale has its own operational and privacy costs.
+
+From a user privacy perspective, that's compelling. From an enterprise security perspective, it's a headache. As I covered in my [encrypted DNS post](https://www.simonpainter.com/encrypted-dns), it breaks wildcard FQDN objects on FortiGate, circumvents DNS-based threat intelligence, and makes DNS visibility nearly impossible without full SSL/TLS interception.
+
+### When to Use DoH
+
+DoH is the choice for public resolvers serving privacy-conscious users on potentially hostile networks. It's also the natural choice if you don't need DNS visibility—if you're an individual user or a small team where DNS monitoring isn't part of your security model.
+
+For internal enterprise DNS, DoH adds complexity without meaningful security gains over DoT. The overhead of full TLS interception to inspect DoH traffic is typically higher than simply using DoT on port 853 with proper logging.
+
+---
+
+## DNS over QUIC (DoQ): The Latency Solution
+
+[RFC 9250](https://datatracker.ietf.org/doc/html/rfc9250) defines DoQ. The design is direct: take DNS-over-TCP (with its 2-byte length prefix), wrap it in QUIC, and run it on port 853.
+
+QUIC is fundamentally different from TCP+TLS. It's a transport protocol with encryption built in as a first-class concern, not added on afterwards.
+
+### Why QUIC Matters
+
+The critical insight from RFC 9250's design considerations is that DoT and UDP DNS solve different problems. UDP DNS is fast but insecure and lacks proper loss recovery. DoT is secure but adds TCP's head-of-line blocking and connection setup overhead. QUIC aims to combine UDP's latency properties with TLS's security and TCP's reliability.
+
+**Connection Setup:** QUIC merges the TCP handshake and TLS handshake. Instead of separate TCP and TLS negotiations, a single round trip gets you an encrypted connection ready to exchange DNS messages. TLS 1.3 over TCP costs 2 RTTs; QUIC costs 1 RTT for the initial connection. For mobile clients making sporadic queries, that's a real difference.
+
+**0-RTT Resumption:** QUIC supports session resumption where a client that previously connected to a server can send encrypted data in the very first packet, before the server responds. A client with a saved session token can include a DNS query in the first packet of connection establishment. If the server supports it, the response might arrive while the handshake is still completing.
+
+**Stream Multiplexing:** Like HTTP/2, QUIC allows multiple streams in-flight without head-of-line blocking. A lost packet affecting stream 5 doesn't stall streams 7 and 9. Each DNS query gets a separate bidirectional stream, so responses can arrive out of order and are processed without waiting.
+
+**Connection Migration:** A QUIC connection survives a client changing networks—WiFi to cellular, for example. The connection state, including any established session token, persists across the transition. TCP connections break immediately if the source IP changes. That matters for mobile clients.
+
+### The Wire Format
+
+```
+QUIC Connection (1-RTT handshake)
+ └── [2-byte length field][DNS wire message]
+     [2-byte length field][DNS wire message]
+     [2-byte length field][DNS wire message]
+```
+
+Like DoT, DoQ uses the 2-byte length field from DNS-over-TCP. Each DNS query/response pair uses a separate stream—the client's first query on stream 0, second on stream 4, third on stream 8, and so on.
+
+RFC 9250 mandates that DNS Message IDs be set to **zero** on DoQ connections. The stream mapping provides unambiguous query/response correlation, making the ID field redundant. This has implications for proxying—a proxy forwarding from DoQ to DoT or UDP has to synthesise a Message ID for the target protocol.
+
+### Operational Characteristics
+
+DoQ shares DoT's port 853 visibility. It's identifiable as encrypted DNS traffic, blockable without interception, and suitable for enterprise governance. But it drops the TCP overhead. For a single query from a cold start, DoQ's 1-RTT handshake is faster than DoT's 2-RTT.
+
+For sustained query streams, the difference narrows because both maintain long-lived connections. But for sporadic clients or mobile devices that frequently establish new connections, DoQ's faster handshake is a genuine win.
+
+### When to Use DoQ
+
+DoQ is most compelling for mobile DNS clients where the lower connection setup cost and connection migration features pay off. It's also well-suited to recursive-to-authoritative zone transfers—no intermediaries to proxy through, and streams allow large multi-response transactions without head-of-line blocking.
+
+For traditional enterprise stub-to-recursive within a data centre, DoT is still simpler and has more mature tooling. For end-user privacy on hostile networks, DoH remains harder to block. DoQ sits between them: better latency than DoT, better visibility than DoH.
+
+---
+
+## Protocol Evolution
+
+Before comparing them directly, it helps to see how the protocols developed:
+
+```mermaid
+timeline
+    title DNS Protocol Timeline
+    1987 : RFC 1035 - Plain DNS over UDP and TCP
+    2005 : RFC 4033-4035 - DNSSEC - authentication without encryption
+    2016 : RFC 7858 - DNS over TLS (DoT) on port 853
+    2018 : RFC 8484 - DNS over HTTPS (DoH) on port 443
+    2022 : RFC 9250 - DNS over QUIC (DoQ) on port 853
+    2023 : RFC 9461 and 9462 - SVCB records and DDR discovery
+    2026 : DoQ goes mainstream with Quad9 and others
+```
+
+---
+
+## Comparative Analysis
+
+### Connection Setup and Latency
+
+| Scenario | DNS/UDP | DoT | DoH | DoQ |
+|----------|---------|-----|-----|-----|
+| First query (cold start) | ~1 RTT | 3-4 RTT | 3-4 RTT | 2-3 RTT |
+| First query (with 0-RTT) | N/A | N/A | N/A | 0-1 RTT |
+| Subsequent query (warm connection) | 1 RTT | 1 RTT | 1 RTT | 1 RTT |
+| Connection keep-alive model | Stateless | 60s idle timeout | 10s idle timeout | Implementation-defined |
+
+Plain DNS is unbeatable for per-query latency. But this is a misleading comparison for most real clients. Most use resolvers they have some persistent relationship with, "warm" connections are the common case once a resolver is chosen, and the encryption overhead is usually smaller than network latency anyway.
+
+The latency win for DoQ appears most clearly in mobile scenarios where connections are frequently re-established.
+
+### Privacy and Visibility
+
+| Aspect | DNS/UDP | DoT | DoH | DoQ |
+|--------|---------|-----|-----|-----|
+| Query content encrypted | No | Yes | Yes | Yes |
+| Response content encrypted | No | Yes | Yes | Yes |
+| Traffic identifiable as DNS | Yes | Yes (port 853) | No (looks like HTTPS) | Yes (port 853) |
+| Observable by network without interception | Fully | Port/timing only | Port/timing only | Port/timing only |
+| Observable by ISP/carrier | Yes | Partially | No | Partially |
+| Observable by enterprise firewall | Yes | Yes | Needs interception | Yes |
+
+The privacy wins are shared across all encrypted methods: the query content isn't visible. The difference is in observability of the fact that DNS occurred at all.
+
+DoH's strength is that it doesn't advertise itself as DNS. DoT and DoQ signal their purpose by using port 853. On a network that monitors DNS, DoH is harder to block or rate-limit without causing false positives on normal HTTPS traffic. But observability isn't always a problem—in enterprise networks, knowing which clients resolve which domains is a security necessity.
+
+### Compatibility and Deployment
+
+| Aspect | DoT | DoH | DoQ |
+|--------|-----|-----|-----|
+| RFC Status | RFC 7858 (2016) | RFC 8484 (2018) | RFC 9250 (2022) |
+| Browser support | No | Yes (Chrome, Firefox, Safari) | Emerging |
+| OS support | Windows 11+, macOS, Linux | Windows 11+, macOS, iOS, Android | Early/limited |
+| Public resolver adoption | Common | Ubiquitous | Growing |
+| Monitoring tools | Mature | Limited | Early |
+
+DoT has been stable for nearly a decade. Tools exist. Vendors support it. But it's not the default in consumer software—browsers don't use it. DoH is everywhere in consumer software, though enterprise tooling for inspection and monitoring is still catching up to DoT. DoQ is the new entrant. Quad9's March 2026 announcement puts DoQ on a major public resolver, giving developers a production system to test against. Client support is still patchy.
+
+### Message Size Handling
+
+| Transport | Max DNS Message Size | MTU Issues | Fragmentation Risk |
+|-----------|----------------------|------------|-------------------|
+| DNS/UDP | 512 bytes (1220 with EDNS0) | Yes | High |
+| DoT | 65535 bytes | No | None |
+| DoH | 65535 bytes | No | None |
+| DoQ | 65535 bytes | No | None |
+
+Plain UDP DNS has a 512-byte limit from RFC 1035. EDNS0 extended this to ~1220 bytes on some paths, but fragmentation becomes a risk. If a large response—like a DNSSEC-signed zone apex—exceeds the path MTU, UDP fragmentation happens. Firewalls drop fragments. The query times out.
+
+All encrypted protocols use the 2-byte length field from DNS-over-TCP, allowing 65535-byte messages. That makes them suitable for zone transfers, large DNSSEC responses, and scenarios with many resource record sets.
+
+### CPU and Network Overhead
+
+| Scenario | Overhead | Notes |
+|----------|----------|-------|
+| DoT per-query | 2-byte length prefix + TLS records | Minimal once connection is warm |
+| DoH POST per-query | HTTP/2 headers (~100-200 bytes) + 2-byte length | More overhead than DoT |
+| DoH GET per-query | HTTP/2 headers + 33% encoding overhead | Worst overhead, but cacheable |
+| DoQ per-query | QUIC frame headers + stream mapping | Similar to DoT, cleaner stream semantics |
+
+For a 33-byte DNS query over a warm connection, DoT carries 35 bytes of application data (plus TLS record headers). DoH POST carries 33 + 2 + approximately 150 bytes of HTTP/2 headers. DoQ carries 35 bytes plus QUIC stream headers. DoT is the leanest. DoQ is close. DoH carries more because HTTP, even compressed, has headers.
+
+---
+
+## Real-World Scenarios
+
+### Scenario 1: Enterprise Internal DNS
+
+Windows or Linux clients querying internal resolvers within a corporate network should use DoT. Port 853 is visible and controllable. Both client and server are under your management. You don't need to accept the DoH/port-443 ambiguity. TLS interception tools are mature. Certificate management is simpler than DoH—no HTTPS SANs, just a TLS cert for the resolver hostname. And you keep operational visibility, which is the point.
+
+Deploy Windows Server DNS 2022+ with DoT support (or BIND/dnsdist/Infoblox with DoT), configure clients via GPO or device management to use port 853, and monitor with your existing DNS logging infrastructure.
+
+### Scenario 2: Public Resolver for Privacy-Conscious Users
+
+A public resolver serving end users who want privacy from their ISP should support all three. DoH reaches users on restrictive networks where port 853 is blocked. DoT suits users who control their networks and want visible, monitorable encrypted DNS. DoQ benefits users with modern clients where latency matters.
+
+This is Quad9's current approach: support all three, advertise via SVCB/HTTPS records, and let clients choose.
+
+### Scenario 3: Mobile App with Sporadic Queries
+
+A mobile application making DNS queries on unreliable networks with frequent transitions should prefer DoQ, with DoH as a fallback. DoQ's 1-RTT handshake and 0-RTT resumption reduce latency on initial queries. Connection migration survives network changes. Per-stream semantics handle out-of-order responses well. If port 853 is blocked, DoH is the fallback.
+
+The practical challenge is client library support—DoQ library support is still limited as of mid-2026, which is why DoH remains the more common choice for mobile developers.
+
+### Scenario 4: Recursive-to-Authoritative Zone Transfer
+
+Zone transfers from authoritative to secondary nameservers suit DoQ well. Zone transfers can be large, but the 65535-byte limit is no longer a constraint. There are no intermediaries, so DoH's HTTP caching offers no benefit. DoQ streams allow multi-response transactions without head-of-line blocking, and per-stream error codes let primaries abort a transfer on one stream without closing the connection entirely.
+
+BIND 9.18+, NSD, and dnsdist all have DoQ support.
+
+---
+
+## DNSSEC: Authentication Without Encryption
+
+Before going further into when encryption matters, it's worth covering DNSSEC—a parallel approach to DNS security that's been standardised since 2005 but remains underdeployed and often misunderstood.
+
+[RFC 4033](https://datatracker.ietf.org/doc/html/rfc4033), [RFC 4034](https://datatracker.ietf.org/doc/html/rfc4034), and [RFC 4035](https://datatracker.ietf.org/doc/html/rfc4035) define DNSSEC. Zone operators cryptographically sign their DNS records. Clients (or validating resolvers) verify those signatures. A valid signature means the response hasn't been tampered with. An invalid or missing signature means it can't be trusted.
+
+### How DNSSEC Works
+
+Each zone has a key pair (KSK, Key Signing Key). When the zone operator publishes records, they sign them with the private key. The signature arrives in the DNS response as an RRSIG record alongside the original data:
+
+```
+example.com. 3600 IN A 192.0.2.1
+example.com. 3600 IN RRSIG A 8 2 3600 20260501000000 20260401000000 (
+    12345 example.com. <base64-encoded-signature-data> )
+```
+
+The client receives both the A record and the RRSIG. It can verify the signature using the public key from the zone's DNSKEY record. DNSSEC doesn't stop at individual zones—it uses a chain of trust. The `.com` nameservers sign DNSKEY records for `example.com`. Root nameservers sign DNSKEY records for `.com`. Clients that trust the root key can validate the entire chain.
+
+### What DNSSEC Solves
+
+DNSSEC gives you **authenticity**: the response came from the authoritative source, not an attacker. **Integrity**: the response hasn't been modified in transit. And **proof of non-existence**: NSEC records cryptographically prove a domain doesn't exist—you can't get a false positive.
+
+DNSSEC is protocol-agnostic. It works over plain DNS/UDP, DoT, DoH, DoQ—anywhere DNS messages travel. The signature is part of the response itself.
+
+### What DNSSEC Doesn't Solve
+
+DNSSEC provides no confidentiality. An observer on the network still sees which domains are being resolved, when, and how often. Even with DNSSEC fully deployed, the stub resolver's query to the recursive resolver is visible to anyone on that hop.
+
+DNSSEC authenticates the answer. It doesn't hide the question.
+
+### DNSSEC Deployment Reality
+
+DNSSEC has been a standards-track protocol for nearly 20 years. The root zone is signed. Most TLDs are signed. Cloudflare, Google, and other major operators sign their zones. Globally, roughly 60-65% of domain names are DNSSEC-signed. But many clients don't validate those signatures.
+
+The operational costs are real. Zone operators must manage key rotation and handle KSK/ZSK hierarchies. DNSSEC responses are larger—RRSIGs, DNSKEY records, and NSEC records add overhead, making UDP fragmentation more likely. Validating resolvers use more CPU. And when DNSSEC validation fails, the problem is often opaque: a misconfigured signing key, an expired signature, or a missing NSEC record all look the same from the client's perspective.
+
+Most end-user clients don't validate DNSSEC. Browsers don't. Operating systems don't (with some exceptions). The validation happens on the resolver—if you trust your resolver to validate, you don't need to validate yourself.
+
+---
+
+## Encryption vs. Authentication: What Enterprises Actually Need
+
+The push toward encrypted DNS assumes that confidentiality is universally necessary. But enterprises have different threat models from end users on potentially hostile networks.
+
+### The Threat Models
+
+An end user on a hostile network worries about their ISP or mobile carrier seeing queries, or a government mandating DNS redirection. Encryption is the answer.
+
+An enterprise on its own network has different priorities. You probably want visibility into your employees' queries—that's how you catch malware, enforce policy, and run threat detection. Your DNS resolver is under your control. The threats you face are malware exfiltrating data via DNS, compromised devices using DNS for C2, and poisoning attacks on your resolver. DNSSEC validation and DNS-based threat intelligence address those directly.
+
+A public resolver like Cloudflare or Quad9 sits in the middle. Users want privacy from their ISP (encryption) and protection against poisoning (DNSSEC). The resolver operator wants to validate responses from authoritative servers (DNSSEC). All of it matters.
+
+### What Each Solves
+
+| Problem | DNSSEC | Encryption (DoT/DoH/DoQ) | Both |
+|---------|--------|--------------------------|------|
+| Response tampering on network | ✓ Solves | ✓ Mitigates | ✓ Optimal |
+| Query visibility to ISP | ✗ Doesn't help | ✓ Solves | ✓ Optimal |
+| Response visibility to ISP | ✗ Doesn't help | ✓ Solves | ✓ Optimal |
+| DNS poisoning attacks | ✓ Solves | ✗ Doesn't help | ✓ Optimal |
+| Operational visibility (enterprise) | ✓ Maintains | ✗ Removes | Depends |
+| Computational cost (resolver) | Higher | Lower | Highest |
+| Backward compatibility | High | Lower | Lower |
+
+The key insight: **encryption and authentication solve different problems.** DNSSEC answers "Is this response from the real nameserver and unmodified?" Encryption answers "Can anyone see that I'm querying this domain?"
+
+### When Enterprises Don't Need Encryption (But Should Use DNSSEC)
+
+Consider a typical enterprise DNS architecture:
+
+```mermaid
+flowchart TD
+    A[Employee Client] -->|"Unencrypted, corporate network"| B["Corporate DNS Resolver\n(validates DNSSEC)"]
+    B -->|DoT or DoQ| C["Upstream Forwarder\n(at perimeter)"]
+    C -->|Encrypted| D["Public Resolver\n(e.g. Quad9)"]
+    D --> E["Authoritative Nameservers\n(DNSSEC-signed)"]
+```
+
+In this architecture, the employee-to-resolver hop runs on your controlled network with your controlled resolver. DNSSEC validation ensures untampered responses. Encryption adds complexity without security benefit.
+
+The resolver-to-upstream hop is where encryption is worth having—you're protecting against ISP snooping on the path to the public internet. The authoritative hop is where DNSSEC validates that the response is genuine.
+
+Many enterprises would gain more from deploying DNSSEC validation on their internal resolvers than from deploying encrypted DNS on the stub-to-resolver hop.
+
+### The Visibility Cost
+
+As I covered in my [encrypted DNS post](https://www.simonpainter.com/encrypted-dns), encrypted DNS removes visibility into queries. That visibility matters operationally. Abnormal query patterns reveal compromised devices or malware. Spikes in queries to known malware domains are detectable via DNS logging. Some regulatory frameworks—HIPAA, PCI-DSS—require DNS logging. When users report connectivity issues, DNS logs are the first diagnostic tool.
+
+DNSSEC doesn't remove this visibility. Queries are still visible—the responses are authenticated, not hidden. That's why I'd recommend DoT over DoH for enterprise internal use: port 853 is visible, port 443 isn't.
+
+Combining DNSSEC validation with visible DNS transport gives you authentication of responses, reasonable privacy where you need it, and the threat detection capability that DNS visibility provides.
+
+### When Both Are Needed
+
+There are legitimate scenarios where DNSSEC and encryption both matter.
+
+A public resolver with DoH and DNSSEC gives end users privacy from their ISP and protection against poisoning. This is Cloudflare's and Quad9's model, and it's the right one for that use case.
+
+An enterprise with an external forwarder can run DNSSEC validation on the internal resolver, encrypt traffic to the external resolver with DoT or DoQ, and maintain visibility on the internal network while protecting privacy on the external hop.
+
+Zone transfer with DNSSEC and DoQ validates zone content authenticity while encrypting the transfer itself. You get tamper protection and confidentiality for zone contents.
+
+---
+
+## Encryption Doesn't Replace Visibility
+
+Here's where I need to be direct. The assumption that encryption solves "DNS security" is incomplete in enterprise contexts.
+
+DNS security has multiple dimensions: **authenticity** (did this response come from the real nameserver?), **confidentiality** (can anyone see what I'm querying?), **integrity** (wasn't the response modified?), and **observability** (can I see what domains are being resolved?).
+
+Enterprises often care more about authenticity, integrity, and observability than confidentiality. End users on hostile networks prioritise confidentiality. The risk of treating encryption as the complete solution is that it removes visibility without adding the authentication DNSSEC provides.
+
+A domain encrypted between client and resolver is still vulnerable to a compromised resolver returning poisoned responses (DNSSEC catches that), malware using DNS for exfiltration (visibility detects it), and operational issues that log analysis would surface (visibility diagnoses them).
+
+The better enterprise strategy is: deploy DNSSEC validation on your recursive resolvers; use DoT for encrypting client-to-resolver traffic if encryption is required; maintain query visibility for security monitoring; block access to unauthorised external resolvers (including via SVCB records); and use DNS-based threat intelligence and malware blocking.
+
+This gives you authentication (DNSSEC), reasonable privacy where needed, and the visibility you need for detection and compliance.
+
+---
+
+## The Evolution Ahead
+
+The encrypted DNS landscape is still moving. A few things to watch.
+
+### DoH3 (DoH over HTTP/3)
+
+Quad9 and others are deploying DoH3—DoH carried over HTTP/3, which runs on QUIC. This gives you DoH's port 443 invisibility combined with QUIC's latency improvements. Modern browsers that support HTTP/3 will automatically upgrade from HTTP/2 DoH to HTTP/3 DoH if the server advertises it via Alt-Svc headers. No client configuration needed.
+
+### Encrypted Recursive-to-Authoritative
+
+Most encrypted DNS work focuses on the stub-to-recursive scenario—clients to resolvers. The recursive-to-authoritative hop is less developed. RFC 9103 (DNS Zone Transfer over TLS) exists, but deployment is minimal. DoQ is gaining traction here because zone transfers don't benefit from HTTP caching and the stream semantics are a better fit.
+
+### DDR Maturity
+
+Discovery of Designated Resolvers (DDR) lets clients discover encrypted transports without manual configuration. Quad9's DoQ deployment, combined with SVCB record advertising, lets clients learn about DoQ automatically. As client support improves, this mechanism will become more important for seamless encrypted DNS adoption.
+
+### The Long Tail of Plain DNS
+
+Plain DNS will remain dominant for years. The infrastructure is vast, the adoption curve for new protocols is gradual, and encrypted DNS will coexist with plaintext DNS for a decade or more. Both will persist—not because either is universally superior, but because the installed base is enormous and migration is expensive. Progress rarely looks like a clean switchover.
+
+---
+
+## Implementation Considerations
+
+### For DNS Server Operators
+
+Start with DoT if you need visibility and control. Add DoH if you're serving privacy-conscious end users. Consider DoQ if you're upgrading infrastructure or serving mobile clients.
+
+Certificate management is the main operational burden. DoT needs TLS certs for the resolver hostname. DoH needs HTTPS certs with correct SANs matching your URI template. DoQ needs TLS certs for the resolver hostname—same as DoT.
+
+### For Client Developers
+
+Support multiple transports if you can: DoH, DoT, and DoQ. Implement fallback logic so clients degrade gracefully if one transport fails. Use DDR to discover encrypted transports automatically if the resolver name is known. Handle connection pooling carefully—different protocols have different idle timeouts and connection costs. And test on real networks with real latency and loss, not just local labs.
+
+### For Enterprise Architects
+
+Deploy DoT internally for encrypted stub-to-recursive within your network. Block port 853 outbound to prevent clients from using external DoT resolvers. Block SVCB/HTTPS record types at your internal resolver to prevent DoH discovery. Monitor for DoH traffic to known external resolver IPs. And don't rely on FQDN blocking alone—determined clients will find workarounds.
+
+The Infoblox model (contain and redirect) remains the right approach: block unauthorised encrypted DNS, then offer your own encrypted service.
+
+---
+
+## Conclusion
+
+DNS encryption isn't new—the protocols are mature, the implementations are solid, and client support is broad. But the evolution from one option (unencrypted) to multiple choices (DoT, DoH, DoQ) changes the operational landscape.
+
+The choice between them isn't about which is abstractly "best." It's about your threat model, your infrastructure, and what you need to see. DoT if you need DNS visibility and control. DoH if your threat model is protection from ISPs and carriers, not internal networks. DoQ if latency matters and you're optimising for mobile. All three if you're a public resolver serving everyone.
+
+The march toward encrypted DNS isn't stopping. Microsoft shipping DoH, Quad9 shipping DoQ, browsers defaulting to DoH—these aren't anomalies. They're the trajectory. DNS that once flowed in the clear, readable to anyone on the path, is becoming the exception rather than the rule.
+
+Whether that's progress or a problem depends entirely on which side of the perimeter you're sitting on.
+
+---
+
+## Further Reading
+
+- [RFC 1035: Domain names - implementation and specification](https://datatracker.ietf.org/doc/html/rfc1035) - The original DNS spec
+- [RFC 4033: DNS Security Introduction and Requirements](https://datatracker.ietf.org/doc/html/rfc4033) - DNSSEC overview
+- [RFC 4034: Resource Records for the DNS Security Extensions](https://datatracker.ietf.org/doc/html/rfc4034) - DNSSEC RRsets and formats
+- [RFC 4035: Protocol Modifications for the DNS Security Extensions](https://datatracker.ietf.org/doc/html/rfc4035) - DNSSEC validation
+- [RFC 7858: DNS over TLS](https://datatracker.ietf.org/doc/html/rfc7858)
+- [RFC 8484: DNS over HTTPS](https://datatracker.ietf.org/doc/html/rfc8484)
+- [RFC 9250: DNS over QUIC](https://datatracker.ietf.org/doc/html/rfc9250)
+- [RFC 8310: Usage Profiles for DNS over TLS and DNS over DTLS](https://datatracker.ietf.org/doc/html/rfc8310)
+- [RFC 9461: SVCB and HTTPS Records for DNS Servers](https://datatracker.ietf.org/doc/html/rfc9461)
+- [RFC 9462: Discovery of Designated Resolvers](https://datatracker.ietf.org/doc/html/rfc9462)
+- [My encrypted DNS post: Governance, visibility, and the FortiGate problem](https://www.simonpainter.com/encrypted-dns)
+- [My SVCB/HTTPS post: Service binding records and encrypted DNS discovery](https://www.simonpainter.com/svcb-https-records)

--- a/blog/dns-dot-doh-doq.md
+++ b/blog/dns-dot-doh-doq.md
@@ -1,6 +1,6 @@
 ---
 
-title: "DNS, DoT, DoH, and DoQ: The Evolution of Encrypted DNS"
+title: "DNS over QUIC: What Quad9's DoQ support means for enterprise DNS"
 authors: simonpainter
 tags:
   - dns
@@ -12,477 +12,227 @@ date: 2026-04-06
 
 ---
 
-Back in February, Microsoft quietly shipped DoH support on Windows Server DNS. In March, Quad9 announced DoQ (DNS over QUIC) alongside DoH3 on their resolver network. These announcements mark a quiet inflection point in how DNS moves across the wire. The protocol landscape has evolved from a single option—unencrypted DNS over UDP—to a real choice between encryption methods, each with different performance characteristics, operational visibility, and security trade-offs.
+In March 2026, Quad9 announced support for DNS over QUIC (DoQ) alongside DoH3 on their public resolver network. That's the same month Microsoft's DoH support for Windows Server DNS moved out of preview. Two announcements in the same month, both about encrypted DNS, and they point in different directions.
 
-This article compares four DNS transport models: plain DNS (the baseline), DNS over TLS (DoT), DNS over HTTPS (DoH), and DNS over QUIC (DoQ). I've already written about [encrypted DNS governance](https://www.simonpainter.com/encrypted-dns) and [SVCB/HTTPS records](https://www.simonpainter.com/svcb-https-records) from the enterprise perspective. This piece steps back to examine the protocols themselves—their design philosophy, their wire-level characteristics, and where each fits in modern infrastructure.
+Microsoft's move continues the push toward DoH—encryption that hides in plain sight on port 443. Quad9's move adds DoQ, which offers better latency than DoT but keeps the port 853 visibility that enterprises actually want. Together they prompt a question I don't think the industry has properly answered yet: are we encrypting DNS for privacy, or for security? Because the answer changes everything about which protocol you should reach for.
 
-The comparison isn't about which protocol is "best." It's about understanding what each protocol was designed to do, what it trades off to get there, and when those trade-offs actually matter in practice.
+This post builds on my earlier work on [encrypted DNS governance](encrypted-dns.md) and [SVCB/HTTPS records](svcb-https-records.md). I'm not going to re-cover the wire format or the DoT vs DoH comparison—read those first if you need the background. This is about DoQ specifically, what QUIC brings to DNS, and why I think the enterprise conversation about encrypted DNS is asking the wrong question.
 
 <!-- truncate -->
 
 ---
 
-## Plain DNS: The Baseline
+## What QUIC Actually Is
 
-Before encryption arrived, DNS was simple. A client sent a query over UDP port 53, the server sent back a response, and that was the transaction. Fast, stateless, and transparent to anyone on the network path.
+Before talking about DoQ, it's worth being clear about what QUIC is—because it's not just "faster TCP."
 
-### The Wire Format
+QUIC is a transport protocol designed from scratch with encryption as a first-class requirement, not an optional layer. It runs over UDP but provides the reliability, ordering, and congestion control you'd expect from TCP. The key distinction is that TLS isn't bolted on top of QUIC the way it is with TCP—the handshake is integrated. You can't have an unencrypted QUIC connection. Encryption is structural.
 
-I covered the DNS message format in detail in my [encrypted DNS post](https://www.simonpainter.com/encrypted-dns), but the headline is: the message itself is 12 bytes of fixed header followed by variable-length question, answer, authority, and additional sections. Most A record queries fit in about 33 bytes total. The response to `example.com?` returning a single A record is about 45 bytes.
+```mermaid
+flowchart LR
+    subgraph TCP Stack
+        direction TB
+        A1[Application] --> B1[TLS] --> C1[TCP] --> D1[IP]
+    end
+    subgraph QUIC Stack
+        direction TB
+        A2[Application] --> B2["QUIC\n(TLS integrated)"] --> C2[UDP] --> D2[IP]
+    end
+```
 
-The message goes straight into a UDP datagram with no framing overhead. Port 53. No encryption. No authentication. The resolver has no way to know if the query came from the client it thought it did, and the client has no way to know if the response came from the resolver it asked.
+That integration matters for DNS because it collapses two separate negotiations—the TCP handshake and the TLS handshake—into one. TLS 1.3 over TCP costs 2 round trips before you can send application data. QUIC costs 1. For a protocol where every millisecond of the lookup adds to page load time, that's meaningful.
 
-### Why It Still Dominates
-
-Despite everything that's come after, plain DNS remains the dominant transport for most queries. It's fast, simple, and works everywhere.
-
-One transaction: client sends 33 bytes on port 53, receives 45 bytes back. Sub-200ms wall-clock time on most networks. Compare that to encrypted transports which need handshakes, TLS negotiation, and connection setup. For a single query, encrypted DNS is slower. For sustained traffic, it catches up because the handshake cost is spread across many queries.
-
-### The Attack Surface
-
-Unencrypted DNS is transparent to any observer on the path. Your ISP sees what domains you resolve. Your corporate firewall sees what your users query. Your government can mandate that ISPs redirect DNS traffic to state-monitored resolvers—and many do. An attacker can forge responses, inject malware-hosting IPs into lookups, or run DNS exfiltration channels for command and control.
-
-None of this is theoretical. I built a [fully functional API proxy on DNS TXT records](https://www.simonpainter.com/dns-api-proxy) in an afternoon. Unencrypted DNS is a covert channel waiting to be exploited.
-
-RFC 9076 (DNS Privacy Considerations) documents the threat model in detail. The security community has been clear about the problem for years. The response has been encryption—but the question has always been: which encryption method?
+QUIC also solves a problem that's plagued multiplexed protocols running over TCP: head-of-line blocking. When TCP loses a packet, everything queued behind it stalls until retransmission succeeds. HTTP/2 over TCP has this problem—you can have 50 requests multiplexed on one connection, but a single lost packet freezes all of them. QUIC handles loss at the stream level. If stream 5 loses a packet, streams 7 and 9 keep moving.
 
 ---
 
-## DNS over TLS (DoT): Encryption Without Overhead
+## DoQ: DNS-over-TCP's Logic, QUIC's Performance
 
-[RFC 7858](https://datatracker.ietf.org/doc/html/rfc7858) defines DoT. The design is straightforward: take DNS-over-TCP (which adds a 2-byte length prefix to handle stream framing), wrap it in TLS, and run it on port 853.
+[RFC 9250](https://datatracker.ietf.org/doc/html/rfc9250) defines DoQ. The wire format is deliberately familiar if you know DoT—it uses the same 2-byte length prefix that DNS-over-TCP introduced, just carried inside QUIC streams rather than a TCP byte stream.
 
-### The Wire Format
+Each DNS query/response pair gets its own bidirectional QUIC stream. The client's first query goes on stream 0, second on stream 4, third on stream 8. Because each is independent, responses can arrive out of order with no head-of-line blocking—the stream ID tells you which query a response belongs to.
 
+RFC 9250 makes one notable departure from conventional DNS: Message IDs must be set to zero on DoQ connections. The stream handles query/response correlation, so the 16-bit ID field that DNS has used since 1987 is redundant. Proxies that translate DoQ to DoT or UDP have to synthesise a real Message ID—something to watch for in implementations.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant R as Resolver
+
+    Note over C,R: Cold start: DoT vs DoQ
+    
+    Note over C,R: DoT needs TCP + TLS (2-3 RTT)
+    C->>R: TCP SYN
+    R->>C: TCP SYN-ACK
+    C->>R: TCP ACK + TLS ClientHello
+    R->>C: TLS ServerHello + Certificate
+    C->>R: TLS Finished + DNS Query (stream)
+    R->>C: DNS Response
+
+    Note over C,R: DoQ needs QUIC Initial only (1-2 RTT)
+    C->>R: QUIC Initial (TLS ClientHello embedded)
+    R->>C: QUIC Handshake (TLS ServerHello + DNS Response)
 ```
-TCP Connection (3-way handshake)
- └── TLS Handshake (typically 1-2 round trips with TLS 1.3)
- └── [2-byte length field][DNS wire message]
-     [2-byte length field][DNS wire message]
-     [2-byte length field][DNS wire message]
-```
 
-The DNS message doesn't change. The length field from TCP-DNS stays. TLS encrypts everything inside the session. The query and response—the domain names being resolved—are hidden. But the metadata isn't: port 853 traffic is visible, along with its volume and timing.
-
-### Built for TCP
-
-TCP adds overhead. The three-way handshake costs 1.5 round trips before any data arrives. TLS adds another round trip (or two with older versions, one with TLS 1.3). By the time the client is ready to send a query, 100+ milliseconds might have passed on a distant connection.
-
-Once connected, though, TCP is efficient. The client can pipeline queries—send multiple queries without waiting for each response, with the transaction ID in the DNS header matching answers to questions. Modern TCP handles loss recovery well for a sustained stream of queries.
-
-DoT is designed to be long-lived. The client opens a connection, sends multiple queries over it, and keeps it alive across transactions. Most DoT implementations configure idle timeouts of 60 seconds or more—the connection is an asset worth keeping warm.
-
-The trade-off is that establishing a new connection is expensive. For mobile clients or those with sporadic query patterns, DoT's connection cost hits harder than UDP's stateless model.
-
-### Operational Visibility
-
-DoT traffic is identifiable by port. A firewall can see port 853 in use without decrypting anything. That's both a strength and a weakness.
-
-The strength: if you want to enforce encrypted DNS while monitoring which resolvers clients reach, DoT is visible. You can count queries by measuring packet rate and block or allow specific resolver IPs without TLS interception.
-
-The weakness: port 853 is identifiable and blockable. A network that wants to prevent encrypted DNS can simply block port 853 outbound. For users in restrictive environments, the visibility that makes DoT operationally clean for administrators makes it fragile for privacy.
-
-### When to Use DoT
-
-DoT is the right choice for enterprise stub-to-recursive deployments—internal clients using internal resolvers. It's also well-suited to any scenario where port 853 visibility is acceptable or desirable. If you operate your own network and want encrypted DNS without losing observability, DoT is the straightforward option.
-
-For public resolver deployments where users might be on hostile networks, DoT is less appealing. Blocking it is trivial.
+The 0-RTT resumption story is where DoQ really separates itself from DoT. When a client has previously connected to a DoQ resolver, it stores a session token. On the next connection, it can send encrypted DNS data in the very first packet—before the server has responded at all. The resolver processes the query and the handshake simultaneously. For mobile clients that cycle through network connections frequently, that's not a theoretical win. It's a real reduction in lookup latency at exactly the moment users notice it most—when an app opens after switching from WiFi to cellular.
 
 ---
 
-## DNS over HTTPS (DoH): Encryption by Stealth
+## What Quad9's Announcement Actually Means
 
-[RFC 8484](https://datatracker.ietf.org/doc/html/rfc8484) takes a different philosophy from DoT. Rather than creating a dedicated transport, DoH encapsulates DNS inside HTTP/2 (or HTTP/3) over standard HTTPS on port 443.
+Quad9 isn't the first public resolver to support DoQ—AdGuard and NextDNS got there earlier—but Quad9 is the first major infrastructure-grade resolver to do so. Quad9 operates 250+ PoPs globally, partners with Shadowserver for threat intelligence, and is a common choice for enterprises that want a privacy-respecting public resolver without Google or Cloudflare in the supply chain.
 
-### The Wire Format
+The announcement also included DoH3—DoH carried over HTTP/3, which runs on QUIC. That's the best-of-both-worlds option if you want DoH's port 443 invisibility alongside QUIC's performance characteristics. Modern browsers that support HTTP/3 will upgrade from DoH/HTTP/2 to DoH3 automatically via Alt-Svc headers.
 
-GET method:
-```
-GET /dns-query?dns=AAABAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB HTTP/2
-Host: dns.example.com
-Accept: application/dns-message
-```
+What changes practically? Two things.
 
-The DNS message is base64url-encoded as a query parameter. Simple, cacheable by intermediaries, but with roughly 33% overhead from base64 encoding.
+First, DoQ now has a production resolver to test against at scale. Until now, DoQ client implementations have mostly been tested against lab setups or small operators. Quad9's global footprint gives library authors and platform teams a real target.
 
-POST method:
-```
-POST /dns-query HTTP/2
-Host: dns.example.com
-Content-Type: application/dns-message
-Content-Length: 33
-
-[raw DNS wire message]
-```
-
-The DNS message goes as the binary request body. No encoding overhead, but responses aren't cacheable by default.
-
-### Why HTTP/2?
-
-DoH runs over HTTP/2, and that matters. HTTP/2 provides stream multiplexing—multiple DNS queries and responses can be in-flight at once on a single TLS connection, identified by stream IDs. This avoids head-of-line blocking where a single lost packet on TCP would stall all subsequent queries. HTTP/2 headers are compressed with HPACK, reducing per-query overhead for repeated headers.
-
-The persistent connection model is the same as DoT: open once, send multiple queries. But because DoH is HTTP, CDNs can cache GET responses, and intermediate proxies can inspect DoH traffic if TLS is intercepted.
-
-### Operational Invisibility
-
-This is where DoH changes things. DoH traffic is structurally identical to ordinary HTTPS web traffic. A firewall sees port 443, which it allows for web browsing. The HTTP/2 headers show requests to `/dns-query`, but those look like any REST API call. Without TLS interception, DoH is indistinguishable from normal web traffic.
-
-That's intentional. It's why DoH became the default in Chrome, Firefox, and increasingly in operating systems. A user on a network that monitors DNS can't block DoH without also decrypting HTTPS—and decrypting HTTPS at scale has its own operational and privacy costs.
-
-From a user privacy perspective, that's compelling. From an enterprise security perspective, it's a headache. As I covered in my [encrypted DNS post](https://www.simonpainter.com/encrypted-dns), it breaks wildcard FQDN objects on FortiGate, circumvents DNS-based threat intelligence, and makes DNS visibility nearly impossible without full SSL/TLS interception.
-
-### When to Use DoH
-
-DoH is the choice for public resolvers serving privacy-conscious users on potentially hostile networks. It's also the natural choice if you don't need DNS visibility—if you're an individual user or a small team where DNS monitoring isn't part of your security model.
-
-For internal enterprise DNS, DoH adds complexity without meaningful security gains over DoT. The overhead of full TLS interception to inspect DoH traffic is typically higher than simply using DoT on port 853 with proper logging.
+Second, DDR (Discovery of Designated Resolvers, [RFC 9462](https://datatracker.ietf.org/doc/html/rfc9462)) becomes more interesting for DoQ. If you're already using Quad9 as your resolver, a DDR-capable client can now discover the DoQ endpoint automatically without manual configuration—the same mechanism I covered in detail in my [SVCB post](svcb-https-records.md). Clients that support both DDR and DoQ can upgrade transparently.
 
 ---
 
-## DNS over QUIC (DoQ): The Latency Solution
-
-[RFC 9250](https://datatracker.ietf.org/doc/html/rfc9250) defines DoQ. The design is direct: take DNS-over-TCP (with its 2-byte length prefix), wrap it in QUIC, and run it on port 853.
-
-QUIC is fundamentally different from TCP+TLS. It's a transport protocol with encryption built in as a first-class concern, not added on afterwards.
-
-### Why QUIC Matters
-
-The critical insight from RFC 9250's design considerations is that DoT and UDP DNS solve different problems. UDP DNS is fast but insecure and lacks proper loss recovery. DoT is secure but adds TCP's head-of-line blocking and connection setup overhead. QUIC aims to combine UDP's latency properties with TLS's security and TCP's reliability.
-
-**Connection Setup:** QUIC merges the TCP handshake and TLS handshake. Instead of separate TCP and TLS negotiations, a single round trip gets you an encrypted connection ready to exchange DNS messages. TLS 1.3 over TCP costs 2 RTTs; QUIC costs 1 RTT for the initial connection. For mobile clients making sporadic queries, that's a real difference.
-
-**0-RTT Resumption:** QUIC supports session resumption where a client that previously connected to a server can send encrypted data in the very first packet, before the server responds. A client with a saved session token can include a DNS query in the first packet of connection establishment. If the server supports it, the response might arrive while the handshake is still completing.
-
-**Stream Multiplexing:** Like HTTP/2, QUIC allows multiple streams in-flight without head-of-line blocking. A lost packet affecting stream 5 doesn't stall streams 7 and 9. Each DNS query gets a separate bidirectional stream, so responses can arrive out of order and are processed without waiting.
-
-**Connection Migration:** A QUIC connection survives a client changing networks—WiFi to cellular, for example. The connection state, including any established session token, persists across the transition. TCP connections break immediately if the source IP changes. That matters for mobile clients.
-
-### The Wire Format
-
-```
-QUIC Connection (1-RTT handshake)
- └── [2-byte length field][DNS wire message]
-     [2-byte length field][DNS wire message]
-     [2-byte length field][DNS wire message]
-```
-
-Like DoT, DoQ uses the 2-byte length field from DNS-over-TCP. Each DNS query/response pair uses a separate stream—the client's first query on stream 0, second on stream 4, third on stream 8, and so on.
-
-RFC 9250 mandates that DNS Message IDs be set to **zero** on DoQ connections. The stream mapping provides unambiguous query/response correlation, making the ID field redundant. This has implications for proxying—a proxy forwarding from DoQ to DoT or UDP has to synthesise a Message ID for the target protocol.
-
-### Operational Characteristics
-
-DoQ shares DoT's port 853 visibility. It's identifiable as encrypted DNS traffic, blockable without interception, and suitable for enterprise governance. But it drops the TCP overhead. For a single query from a cold start, DoQ's 1-RTT handshake is faster than DoT's 2-RTT.
-
-For sustained query streams, the difference narrows because both maintain long-lived connections. But for sporadic clients or mobile devices that frequently establish new connections, DoQ's faster handshake is a genuine win.
-
-### When to Use DoQ
-
-DoQ is most compelling for mobile DNS clients where the lower connection setup cost and connection migration features pay off. It's also well-suited to recursive-to-authoritative zone transfers—no intermediaries to proxy through, and streams allow large multi-response transactions without head-of-line blocking.
-
-For traditional enterprise stub-to-recursive within a data centre, DoT is still simpler and has more mature tooling. For end-user privacy on hostile networks, DoH remains harder to block. DoQ sits between them: better latency than DoT, better visibility than DoH.
-
----
-
-## Protocol Evolution
-
-Before comparing them directly, it helps to see how the protocols developed:
+## The Protocol Landscape Now
 
 ```mermaid
 timeline
-    title DNS Protocol Timeline
-    1987 : RFC 1035 - Plain DNS over UDP and TCP
-    2005 : RFC 4033-4035 - DNSSEC - authentication without encryption
-    2016 : RFC 7858 - DNS over TLS (DoT) on port 853
-    2018 : RFC 8484 - DNS over HTTPS (DoH) on port 443
-    2022 : RFC 9250 - DNS over QUIC (DoQ) on port 853
-    2023 : RFC 9461 and 9462 - SVCB records and DDR discovery
-    2026 : DoQ goes mainstream with Quad9 and others
+    title Encrypted DNS: From RFC to Production
+    2016 : RFC 7858 - DoT - port 853, TCP+TLS, enterprise-friendly
+    2018 : RFC 8484 - DoH - port 443, HTTP/2, browser-default
+    2022 : RFC 9250 - DoQ - port 853, QUIC, latency-optimised
+    2023 : RFC 9461 and 9462 - SVCB and DDR - automatic discovery
+    2026 : DoQ reaches production scale with Quad9 and DoH3
 ```
 
----
+The choice of protocol has always been about more than performance. Where you run your DNS and who you need to trust shapes which protocol makes sense.
 
-## Comparative Analysis
+DoH runs on port 443 and is indistinguishable from ordinary HTTPS. That's by design—it protects privacy from network observers including enterprise firewalls. As I covered in [my first encrypted DNS post](encrypted-dns.md), this is exactly what breaks FortiGate wildcard FQDN objects and circumvents DNS-based threat intelligence. DoH prioritises user confidentiality over organisational visibility.
 
-### Connection Setup and Latency
+DoT and DoQ both run on port 853 and are identifiable as encrypted DNS without any decryption. A firewall can see the traffic, measure its volume, and block or allow specific resolver IPs. Enterprises that want encrypted DNS without losing observability have always been pushed toward DoT. Now they have DoQ as an alternative with better connection setup characteristics.
 
-| Scenario | DNS/UDP | DoT | DoH | DoQ |
-|----------|---------|-----|-----|-----|
-| First query (cold start) | ~1 RTT | 3-4 RTT | 3-4 RTT | 2-3 RTT |
-| First query (with 0-RTT) | N/A | N/A | N/A | 0-1 RTT |
-| Subsequent query (warm connection) | 1 RTT | 1 RTT | 1 RTT | 1 RTT |
-| Connection keep-alive model | Stateless | 60s idle timeout | 10s idle timeout | Implementation-defined |
+The meaningful comparison for enterprise architects isn't DoT vs DoH any more—it's DoT vs DoQ, with DoH as the external-facing option for users on untrusted networks.
 
-Plain DNS is unbeatable for per-query latency. But this is a misleading comparison for most real clients. Most use resolvers they have some persistent relationship with, "warm" connections are the common case once a resolver is chosen, and the encryption overhead is usually smaller than network latency anyway.
-
-The latency win for DoQ appears most clearly in mobile scenarios where connections are frequently re-established.
-
-### Privacy and Visibility
-
-| Aspect | DNS/UDP | DoT | DoH | DoQ |
-|--------|---------|-----|-----|-----|
-| Query content encrypted | No | Yes | Yes | Yes |
-| Response content encrypted | No | Yes | Yes | Yes |
-| Traffic identifiable as DNS | Yes | Yes (port 853) | No (looks like HTTPS) | Yes (port 853) |
-| Observable by network without interception | Fully | Port/timing only | Port/timing only | Port/timing only |
-| Observable by ISP/carrier | Yes | Partially | No | Partially |
-| Observable by enterprise firewall | Yes | Yes | Needs interception | Yes |
-
-The privacy wins are shared across all encrypted methods: the query content isn't visible. The difference is in observability of the fact that DNS occurred at all.
-
-DoH's strength is that it doesn't advertise itself as DNS. DoT and DoQ signal their purpose by using port 853. On a network that monitors DNS, DoH is harder to block or rate-limit without causing false positives on normal HTTPS traffic. But observability isn't always a problem—in enterprise networks, knowing which clients resolve which domains is a security necessity.
-
-### Compatibility and Deployment
-
-| Aspect | DoT | DoH | DoQ |
+| Aspect | DoT | DoQ | DoH |
 |--------|-----|-----|-----|
-| RFC Status | RFC 7858 (2016) | RFC 8484 (2018) | RFC 9250 (2022) |
-| Browser support | No | Yes (Chrome, Firefox, Safari) | Emerging |
-| OS support | Windows 11+, macOS, Linux | Windows 11+, macOS, iOS, Android | Early/limited |
-| Public resolver adoption | Common | Ubiquitous | Growing |
-| Monitoring tools | Mature | Limited | Early |
-
-DoT has been stable for nearly a decade. Tools exist. Vendors support it. But it's not the default in consumer software—browsers don't use it. DoH is everywhere in consumer software, though enterprise tooling for inspection and monitoring is still catching up to DoT. DoQ is the new entrant. Quad9's March 2026 announcement puts DoQ on a major public resolver, giving developers a production system to test against. Client support is still patchy.
-
-### Message Size Handling
-
-| Transport | Max DNS Message Size | MTU Issues | Fragmentation Risk |
-|-----------|----------------------|------------|-------------------|
-| DNS/UDP | 512 bytes (1220 with EDNS0) | Yes | High |
-| DoT | 65535 bytes | No | None |
-| DoH | 65535 bytes | No | None |
-| DoQ | 65535 bytes | No | None |
-
-Plain UDP DNS has a 512-byte limit from RFC 1035. EDNS0 extended this to ~1220 bytes on some paths, but fragmentation becomes a risk. If a large response—like a DNSSEC-signed zone apex—exceeds the path MTU, UDP fragmentation happens. Firewalls drop fragments. The query times out.
-
-All encrypted protocols use the 2-byte length field from DNS-over-TCP, allowing 65535-byte messages. That makes them suitable for zone transfers, large DNSSEC responses, and scenarios with many resource record sets.
-
-### CPU and Network Overhead
-
-| Scenario | Overhead | Notes |
-|----------|----------|-------|
-| DoT per-query | 2-byte length prefix + TLS records | Minimal once connection is warm |
-| DoH POST per-query | HTTP/2 headers (~100-200 bytes) + 2-byte length | More overhead than DoT |
-| DoH GET per-query | HTTP/2 headers + 33% encoding overhead | Worst overhead, but cacheable |
-| DoQ per-query | QUIC frame headers + stream mapping | Similar to DoT, cleaner stream semantics |
-
-For a 33-byte DNS query over a warm connection, DoT carries 35 bytes of application data (plus TLS record headers). DoH POST carries 33 + 2 + approximately 150 bytes of HTTP/2 headers. DoQ carries 35 bytes plus QUIC stream headers. DoT is the leanest. DoQ is close. DoH carries more because HTTP, even compressed, has headers.
+| Port | 853 | 853 | 443 |
+| Transport | TCP + TLS | QUIC (TLS integrated) | TCP + TLS + HTTP/2 |
+| Cold start RTT | 2-3 | 1-2 | 2-3 |
+| 0-RTT resumption | No | Yes | No |
+| Head-of-line blocking | Yes (TCP) | No | Partial (HTTP/2) |
+| Identifiable as DNS | Yes | Yes | No |
+| Enterprise visibility | Yes | Yes | Needs interception |
+| Tooling maturity | High | Early | Medium |
 
 ---
 
-## Real-World Scenarios
+## The Question Nobody's Asking
 
-### Scenario 1: Enterprise Internal DNS
+Here's where I want to push back on the framing that's dominated the encrypted DNS conversation since 2018.
 
-Windows or Linux clients querying internal resolvers within a corporate network should use DoT. Port 853 is visible and controllable. Both client and server are under your management. You don't need to accept the DoH/port-443 ambiguity. TLS interception tools are mature. Certificate management is simpler than DoH—no HTTPS SANs, just a TLS cert for the resolver hostname. And you keep operational visibility, which is the point.
+The standard narrative goes like this: DNS is insecure, so we need to encrypt it, and the argument is only about which encryption method. That's true for end users querying from a coffee shop or a hotel WiFi. But for enterprises, it's the wrong question.
 
-Deploy Windows Server DNS 2022+ with DoT support (or BIND/dnsdist/Infoblox with DoT), configure clients via GPO or device management to use port 853, and monitor with your existing DNS logging infrastructure.
+DNS security has two separate concerns that the community keeps conflating. **Confidentiality** is about whether an observer on the network can see your queries. **Authentication** is about whether the response you receive is genuine—whether it came from the real nameserver and hasn't been tampered with in transit.
 
-### Scenario 2: Public Resolver for Privacy-Conscious Users
+Encrypted DNS (DoT, DoH, DoQ) solves confidentiality. DNSSEC solves authentication.
 
-A public resolver serving end users who want privacy from their ISP should support all three. DoH reaches users on restrictive networks where port 853 is blocked. DoT suits users who control their networks and want visible, monitorable encrypted DNS. DoQ benefits users with modern clients where latency matters.
+For a user on an untrusted network, confidentiality matters. Their ISP, their government, the person running the coffee shop's router—all of these are potential observers. Encryption hides the query.
 
-This is Quad9's current approach: support all three, advertise via SVCB/HTTPS records, and let clients choose.
-
-### Scenario 3: Mobile App with Sporadic Queries
-
-A mobile application making DNS queries on unreliable networks with frequent transitions should prefer DoQ, with DoH as a fallback. DoQ's 1-RTT handshake and 0-RTT resumption reduce latency on initial queries. Connection migration survives network changes. Per-stream semantics handle out-of-order responses well. If port 853 is blocked, DoH is the fallback.
-
-The practical challenge is client library support—DoQ library support is still limited as of mid-2026, which is why DoH remains the more common choice for mobile developers.
-
-### Scenario 4: Recursive-to-Authoritative Zone Transfer
-
-Zone transfers from authoritative to secondary nameservers suit DoQ well. Zone transfers can be large, but the 65535-byte limit is no longer a constraint. There are no intermediaries, so DoH's HTTP caching offers no benefit. DoQ streams allow multi-response transactions without head-of-line blocking, and per-stream error codes let primaries abort a transfer on one stream without closing the connection entirely.
-
-BIND 9.18+, NSD, and dnsdist all have DoQ support.
+For an enterprise, the threat model is different. You own the network between the client and your internal resolver. The risk isn't an observer on the wire—it's a compromised resolver returning poisoned responses, or malware using DNS for exfiltration and C2. Encryption doesn't address either of those. DNSSEC addresses the first. Visibility—the ability to see what's being queried—addresses the second.
 
 ---
 
-## DNSSEC: Authentication Without Encryption
+## DNSSEC: The Security Property Enterprises Actually Need
 
-Before going further into when encryption matters, it's worth covering DNSSEC—a parallel approach to DNS security that's been standardised since 2005 but remains underdeployed and often misunderstood.
+DNSSEC ([RFC 4033](https://datatracker.ietf.org/doc/html/rfc4033), [RFC 4034](https://datatracker.ietf.org/doc/html/rfc4034), [RFC 4035](https://datatracker.ietf.org/doc/html/rfc4035)) has been a standard since 2005. It's underdeployed and widely misunderstood. Let me explain what it actually does.
 
-[RFC 4033](https://datatracker.ietf.org/doc/html/rfc4033), [RFC 4034](https://datatracker.ietf.org/doc/html/rfc4034), and [RFC 4035](https://datatracker.ietf.org/doc/html/rfc4035) define DNSSEC. Zone operators cryptographically sign their DNS records. Clients (or validating resolvers) verify those signatures. A valid signature means the response hasn't been tampered with. An invalid or missing signature means it can't be trusted.
-
-### How DNSSEC Works
-
-Each zone has a key pair (KSK, Key Signing Key). When the zone operator publishes records, they sign them with the private key. The signature arrives in the DNS response as an RRSIG record alongside the original data:
+Zone operators sign their DNS records with a private key. The signature arrives in the response as an RRSIG record alongside the real data:
 
 ```
-example.com. 3600 IN A 192.0.2.1
+example.com. 3600 IN A 93.184.216.34
 example.com. 3600 IN RRSIG A 8 2 3600 20260501000000 20260401000000 (
-    12345 example.com. <base64-encoded-signature-data> )
+    12345 example.com. <base64-encoded-signature> )
 ```
 
-The client receives both the A record and the RRSIG. It can verify the signature using the public key from the zone's DNSKEY record. DNSSEC doesn't stop at individual zones—it uses a chain of trust. The `.com` nameservers sign DNSKEY records for `example.com`. Root nameservers sign DNSKEY records for `.com`. Clients that trust the root key can validate the entire chain.
+A validating resolver checks that signature against the zone's public key (in the DNSKEY record). If it validates, the response is genuine. If it doesn't, the response is rejected—regardless of how plausible it looks. An attacker can't forge a valid RRSIG without the zone operator's private key.
 
-### What DNSSEC Solves
+DNSSEC uses a chain of trust. The `.com` nameservers sign the DNSKEY records for `example.com`. Root nameservers sign the DNSKEY records for `.com`. A resolver that trusts the root key—which is published and well-known—can validate the entire chain from root to leaf. Compromise of a recursive resolver can't produce a valid RRSIG without the zone's private key.
 
-DNSSEC gives you **authenticity**: the response came from the authoritative source, not an attacker. **Integrity**: the response hasn't been modified in transit. And **proof of non-existence**: NSEC records cryptographically prove a domain doesn't exist—you can't get a false positive.
+That's the property you want in an enterprise. If your internal resolver is validating DNSSEC, a DNS poisoning attack that redirects `payments.internal` to a malicious IP will fail because it can't produce a valid signature. Encryption of the query doesn't give you this—an encrypted query to a compromised resolver just gets you a confidential wrong answer.
 
-DNSSEC is protocol-agnostic. It works over plain DNS/UDP, DoT, DoH, DoQ—anywhere DNS messages travel. The signature is part of the response itself.
+DNSSEC is protocol-agnostic. It works over plain DNS/UDP, DoT, DoH, or DoQ. The signature is in the response, not the transport. You can have DNSSEC validation without any encryption, and you can have encrypted DNS without any DNSSEC. They're independent.
 
-### What DNSSEC Doesn't Solve
+### The Deployment Reality
 
-DNSSEC provides no confidentiality. An observer on the network still sees which domains are being resolved, when, and how often. Even with DNSSEC fully deployed, the stub resolver's query to the recursive resolver is visible to anyone on that hop.
+Roughly 60-65% of domain names are DNSSEC-signed globally. Most TLDs are signed. The root is signed. Cloudflare, Google, Quad9, and other major resolver operators validate DNSSEC by default.
 
-DNSSEC authenticates the answer. It doesn't hide the question.
+But most enterprises don't run DNSSEC validation on their internal resolvers. They've deployed split-horizon DNS for internal zones. They've spent effort on encrypted DNS transport. They've blocked port 853 outbound. And they've left the door open to response tampering because their recursive resolver doesn't validate signatures.
 
-### DNSSEC Deployment Reality
-
-DNSSEC has been a standards-track protocol for nearly 20 years. The root zone is signed. Most TLDs are signed. Cloudflare, Google, and other major operators sign their zones. Globally, roughly 60-65% of domain names are DNSSEC-signed. But many clients don't validate those signatures.
-
-The operational costs are real. Zone operators must manage key rotation and handle KSK/ZSK hierarchies. DNSSEC responses are larger—RRSIGs, DNSKEY records, and NSEC records add overhead, making UDP fragmentation more likely. Validating resolvers use more CPU. And when DNSSEC validation fails, the problem is often opaque: a misconfigured signing key, an expired signature, or a missing NSEC record all look the same from the client's perspective.
-
-Most end-user clients don't validate DNSSEC. Browsers don't. Operating systems don't (with some exceptions). The validation happens on the resolver—if you trust your resolver to validate, you don't need to validate yourself.
+The DNSSEC operational overhead is real—key rotation, larger response sizes due to RRSIG records, occasional validation failures that are painful to debug. But that overhead is lower than deploying and maintaining TLS interception infrastructure to inspect DoH traffic.
 
 ---
 
-## Encryption vs. Authentication: What Enterprises Actually Need
+## Authentication vs Confidentiality in Practice
 
-The push toward encrypted DNS assumes that confidentiality is universally necessary. But enterprises have different threat models from end users on potentially hostile networks.
+Consider the threat models honestly.
 
-### The Threat Models
-
-An end user on a hostile network worries about their ISP or mobile carrier seeing queries, or a government mandating DNS redirection. Encryption is the answer.
-
-An enterprise on its own network has different priorities. You probably want visibility into your employees' queries—that's how you catch malware, enforce policy, and run threat detection. Your DNS resolver is under your control. The threats you face are malware exfiltrating data via DNS, compromised devices using DNS for C2, and poisoning attacks on your resolver. DNSSEC validation and DNS-based threat intelligence address those directly.
-
-A public resolver like Cloudflare or Quad9 sits in the middle. Users want privacy from their ISP (encryption) and protection against poisoning (DNSSEC). The resolver operator wants to validate responses from authoritative servers (DNSSEC). All of it matters.
-
-### What Each Solves
-
-| Problem | DNSSEC | Encryption (DoT/DoH/DoQ) | Both |
-|---------|--------|--------------------------|------|
-| Response tampering on network | ✓ Solves | ✓ Mitigates | ✓ Optimal |
-| Query visibility to ISP | ✗ Doesn't help | ✓ Solves | ✓ Optimal |
-| Response visibility to ISP | ✗ Doesn't help | ✓ Solves | ✓ Optimal |
-| DNS poisoning attacks | ✓ Solves | ✗ Doesn't help | ✓ Optimal |
-| Operational visibility (enterprise) | ✓ Maintains | ✗ Removes | Depends |
-| Computational cost (resolver) | Higher | Lower | Highest |
-| Backward compatibility | High | Lower | Lower |
-
-The key insight: **encryption and authentication solve different problems.** DNSSEC answers "Is this response from the real nameserver and unmodified?" Encryption answers "Can anyone see that I'm querying this domain?"
-
-### When Enterprises Don't Need Encryption (But Should Use DNSSEC)
-
-Consider a typical enterprise DNS architecture:
+An enterprise DNS resolver sits on your network, answering queries from your clients. The path from client to resolver is on infrastructure you control. The path from resolver to upstream forwarder might cross ISP networks. The path from forwarder to authoritative nameserver crosses the public internet.
 
 ```mermaid
 flowchart TD
-    A[Employee Client] -->|"Unencrypted, corporate network"| B["Corporate DNS Resolver\n(validates DNSSEC)"]
-    B -->|DoT or DoQ| C["Upstream Forwarder\n(at perimeter)"]
-    C -->|Encrypted| D["Public Resolver\n(e.g. Quad9)"]
-    D --> E["Authoritative Nameservers\n(DNSSEC-signed)"]
+    A[Employee Client] -->|"Your network\nDNSSEC validates responses"| B["Internal Recursive Resolver"]
+    B -->|"DoT to public resolver\nconfidentiality on untrusted path"| C["Public Resolver e.g. Quad9\nvalidates DNSSEC"]
+    C -->|"DNSSEC chain of trust"| D["Authoritative Nameservers\nDNSSEC-signed zones"]
+    
+    style B fill:#d4edda
+    style C fill:#d4edda
+    style D fill:#d4edda
 ```
 
-In this architecture, the employee-to-resolver hop runs on your controlled network with your controlled resolver. DNSSEC validation ensures untampered responses. Encryption adds complexity without security benefit.
+On the internal hop, you control the network. DNSSEC validation at your resolver means tampered responses are rejected. You don't need to encrypt this hop for security reasons—and encrypting it removes the query visibility you need for threat detection.
 
-The resolver-to-upstream hop is where encryption is worth having—you're protecting against ISP snooping on the path to the public internet. The authoritative hop is where DNSSEC validates that the response is genuine.
+On the resolver-to-public-internet hop, you're crossing untrusted infrastructure. DoT or DoQ makes sense here—you want confidentiality from ISP monitoring, and port 853 keeps the traffic identifiable for your own governance.
 
-Many enterprises would gain more from deploying DNSSEC validation on their internal resolvers than from deploying encrypted DNS on the stub-to-resolver hop.
+The authoritative layer is protected by DNSSEC signatures. A compromised public resolver can't fake a valid RRSIG for a zone it doesn't control.
 
-### The Visibility Cost
+The result: DNSSEC validation on your recursive resolver + DoT or DoQ on the upstream hop gives you authentication at every layer and confidentiality where the network is untrusted. It maintains query visibility on the internal hop, where you need it for security monitoring.
 
-As I covered in my [encrypted DNS post](https://www.simonpainter.com/encrypted-dns), encrypted DNS removes visibility into queries. That visibility matters operationally. Abnormal query patterns reveal compromised devices or malware. Spikes in queries to known malware domains are detectable via DNS logging. Some regulatory frameworks—HIPAA, PCI-DSS—require DNS logging. When users report connectivity issues, DNS logs are the first diagnostic tool.
+Deploying DoH internally gives you confidentiality on a hop you already control, removes the query visibility you need, and still leaves you vulnerable to response tampering if your resolver isn't validating DNSSEC.
 
-DNSSEC doesn't remove this visibility. Queries are still visible—the responses are authenticated, not hidden. That's why I'd recommend DoT over DoH for enterprise internal use: port 853 is visible, port 443 isn't.
-
-Combining DNSSEC validation with visible DNS transport gives you authentication of responses, reasonable privacy where you need it, and the threat detection capability that DNS visibility provides.
-
-### When Both Are Needed
-
-There are legitimate scenarios where DNSSEC and encryption both matter.
-
-A public resolver with DoH and DNSSEC gives end users privacy from their ISP and protection against poisoning. This is Cloudflare's and Quad9's model, and it's the right one for that use case.
-
-An enterprise with an external forwarder can run DNSSEC validation on the internal resolver, encrypt traffic to the external resolver with DoT or DoQ, and maintain visibility on the internal network while protecting privacy on the external hop.
-
-Zone transfer with DNSSEC and DoQ validates zone content authenticity while encrypting the transfer itself. You get tamper protection and confidentiality for zone contents.
+I'd take DNSSEC validation on a plaintext resolver over DoH without DNSSEC validation, every time, for an internal enterprise deployment.
 
 ---
 
-## Encryption Doesn't Replace Visibility
+## What DoQ Changes for Enterprises
 
-Here's where I need to be direct. The assumption that encryption solves "DNS security" is incomplete in enterprise contexts.
+DoQ doesn't resolve the confidentiality vs authentication debate. But it does change the picture for enterprises that want encrypted DNS on the upstream hop without sacrificing visibility.
 
-DNS security has multiple dimensions: **authenticity** (did this response come from the real nameserver?), **confidentiality** (can anyone see what I'm querying?), **integrity** (wasn't the response modified?), and **observability** (can I see what domains are being resolved?).
+DoT has been the enterprise-friendly option since 2016, but it carries TCP's connection setup cost. For long-lived connections between a corporate resolver and a public upstream forwarder with high query volumes, that overhead is amortised and barely matters. For deployments with frequent connection resets—cloud-native environments, serverless functions making sporadic queries, or IoT devices with intermittent connectivity—DoT's 2-3 RTT cold start is a real cost.
 
-Enterprises often care more about authenticity, integrity, and observability than confidentiality. End users on hostile networks prioritise confidentiality. The risk of treating encryption as the complete solution is that it removes visibility without adding the authentication DNSSEC provides.
+DoQ's 1-RTT handshake and 0-RTT resumption make it a better fit for those sporadic patterns. And because it runs on port 853, it stays visible to enterprise governance tools in the same way DoT does.
 
-A domain encrypted between client and resolver is still vulnerable to a compromised resolver returning poisoned responses (DNSSEC catches that), malware using DNS for exfiltration (visibility detects it), and operational issues that log analysis would surface (visibility diagnoses them).
+DoQ also has better characteristics for zone transfers. Zone content can be large. Multiple resource record sets in a single transfer can hit UDP fragmentation limits. DoQ's per-stream independence means a large transfer doesn't stall other queries on the same connection, and per-stream error codes let a primary abort a transfer without dropping the whole connection. BIND 9.18+ and dnsdist both support DoQ for zone transfer.
 
-The better enterprise strategy is: deploy DNSSEC validation on your recursive resolvers; use DoT for encrypting client-to-resolver traffic if encryption is required; maintain query visibility for security monitoring; block access to unauthorised external resolvers (including via SVCB records); and use DNS-based threat intelligence and malware blocking.
-
-This gives you authentication (DNSSEC), reasonable privacy where needed, and the visibility you need for detection and compliance.
+The tooling maturity gap is real—DoQ monitoring and inspection tools are considerably less developed than DoT equivalents. If you're considering DoQ for enterprise internal use today, factor in that your observability tooling may need to catch up.
 
 ---
 
-## The Evolution Ahead
+## The Practical Upshot
 
-The encrypted DNS landscape is still moving. A few things to watch.
+If you haven't already, the most impactful thing you can do for your enterprise DNS security posture isn't deploying encrypted transports. It's enabling DNSSEC validation on your internal recursive resolvers. Both Windows Server DNS (2019+) and BIND support it with minimal configuration change. Your upstream resolvers (Quad9, Cloudflare, Google) already validate—make sure your internal resolvers do too.
 
-### DoH3 (DoH over HTTP/3)
+Once that's in place, use DoT on the upstream forwarder hop—from your internal resolver to your public DNS provider. This gives confidentiality where the network is untrusted and maintains visibility on the internal network.
 
-Quad9 and others are deploying DoH3—DoH carried over HTTP/3, which runs on QUIC. This gives you DoH's port 443 invisibility combined with QUIC's latency improvements. Modern browsers that support HTTP/3 will automatically upgrade from HTTP/2 DoH to HTTP/3 DoH if the server advertises it via Alt-Svc headers. No client configuration needed.
+DoH belongs at the edge, not inside the perimeter. For users on untrusted networks—remote workers, mobile devices away from corporate infrastructure—DoH provides confidentiality from their local network observer. Inside your perimeter, it removes visibility for no additional security gain over DNSSEC + DoT.
 
-### Encrypted Recursive-to-Authoritative
-
-Most encrypted DNS work focuses on the stub-to-recursive scenario—clients to resolvers. The recursive-to-authoritative hop is less developed. RFC 9103 (DNS Zone Transfer over TLS) exists, but deployment is minimal. DoQ is gaining traction here because zone transfers don't benefit from HTTP caching and the stream semantics are a better fit.
-
-### DDR Maturity
-
-Discovery of Designated Resolvers (DDR) lets clients discover encrypted transports without manual configuration. Quad9's DoQ deployment, combined with SVCB record advertising, lets clients learn about DoQ automatically. As client support improves, this mechanism will become more important for seamless encrypted DNS adoption.
-
-### The Long Tail of Plain DNS
-
-Plain DNS will remain dominant for years. The infrastructure is vast, the adoption curve for new protocols is gradual, and encrypted DNS will coexist with plaintext DNS for a decade or more. Both will persist—not because either is universally superior, but because the installed base is enormous and migration is expensive. Progress rarely looks like a clean switchover.
-
----
-
-## Implementation Considerations
-
-### For DNS Server Operators
-
-Start with DoT if you need visibility and control. Add DoH if you're serving privacy-conscious end users. Consider DoQ if you're upgrading infrastructure or serving mobile clients.
-
-Certificate management is the main operational burden. DoT needs TLS certs for the resolver hostname. DoH needs HTTPS certs with correct SANs matching your URI template. DoQ needs TLS certs for the resolver hostname—same as DoT.
-
-### For Client Developers
-
-Support multiple transports if you can: DoH, DoT, and DoQ. Implement fallback logic so clients degrade gracefully if one transport fails. Use DDR to discover encrypted transports automatically if the resolver name is known. Handle connection pooling carefully—different protocols have different idle timeouts and connection costs. And test on real networks with real latency and loss, not just local labs.
-
-### For Enterprise Architects
-
-Deploy DoT internally for encrypted stub-to-recursive within your network. Block port 853 outbound to prevent clients from using external DoT resolvers. Block SVCB/HTTPS record types at your internal resolver to prevent DoH discovery. Monitor for DoH traffic to known external resolver IPs. And don't rely on FQDN blocking alone—determined clients will find workarounds.
-
-The Infoblox model (contain and redirect) remains the right approach: block unauthorised encrypted DNS, then offer your own encrypted service.
-
----
-
-## Conclusion
-
-DNS encryption isn't new—the protocols are mature, the implementations are solid, and client support is broad. But the evolution from one option (unencrypted) to multiple choices (DoT, DoH, DoQ) changes the operational landscape.
-
-The choice between them isn't about which is abstractly "best." It's about your threat model, your infrastructure, and what you need to see. DoT if you need DNS visibility and control. DoH if your threat model is protection from ISPs and carriers, not internal networks. DoQ if latency matters and you're optimising for mobile. All three if you're a public resolver serving everyone.
-
-The march toward encrypted DNS isn't stopping. Microsoft shipping DoH, Quad9 shipping DoQ, browsers defaulting to DoH—these aren't anomalies. They're the trajectory. DNS that once flowed in the clear, readable to anyone on the path, is becoming the exception rather than the rule.
-
-Whether that's progress or a problem depends entirely on which side of the perimeter you're sitting on.
+DoQ is worth watching for the upstream forwarder role, especially if you're running cloud-native or serverless workloads where connection churn is high. Quad9's production deployment means there's now a well-tested target to build against. Expect tooling to mature over the next 12-18 months.
 
 ---
 
 ## Further Reading
 
-- [RFC 1035: Domain names - implementation and specification](https://datatracker.ietf.org/doc/html/rfc1035) - The original DNS spec
-- [RFC 4033: DNS Security Introduction and Requirements](https://datatracker.ietf.org/doc/html/rfc4033) - DNSSEC overview
-- [RFC 4034: Resource Records for the DNS Security Extensions](https://datatracker.ietf.org/doc/html/rfc4034) - DNSSEC RRsets and formats
-- [RFC 4035: Protocol Modifications for the DNS Security Extensions](https://datatracker.ietf.org/doc/html/rfc4035) - DNSSEC validation
-- [RFC 7858: DNS over TLS](https://datatracker.ietf.org/doc/html/rfc7858)
-- [RFC 8484: DNS over HTTPS](https://datatracker.ietf.org/doc/html/rfc8484)
 - [RFC 9250: DNS over QUIC](https://datatracker.ietf.org/doc/html/rfc9250)
-- [RFC 8310: Usage Profiles for DNS over TLS and DNS over DTLS](https://datatracker.ietf.org/doc/html/rfc8310)
+- [RFC 4033-4035: DNSSEC](https://datatracker.ietf.org/doc/html/rfc4033)
 - [RFC 9461: SVCB and HTTPS Records for DNS Servers](https://datatracker.ietf.org/doc/html/rfc9461)
 - [RFC 9462: Discovery of Designated Resolvers](https://datatracker.ietf.org/doc/html/rfc9462)
-- [My encrypted DNS post: Governance, visibility, and the FortiGate problem](https://www.simonpainter.com/encrypted-dns)
-- [My SVCB/HTTPS post: Service binding records and encrypted DNS discovery](https://www.simonpainter.com/svcb-https-records)
+- [My encrypted DNS post: DoH, DoT, enterprise visibility, and the FortiGate problem](encrypted-dns.md)
+- [My SVCB/HTTPS post: Service binding records, DDR, and how clients discover encrypted resolvers](svcb-https-records.md)

--- a/blog/dns-dot-doh-doq.md
+++ b/blog/dns-dot-doh-doq.md
@@ -12,15 +12,13 @@ date: 2026-04-06
 
 ---
 
-In March 2026, Quad9 announced support for DNS over QUIC (DoQ) alongside DoH3 on their public resolver network. That's the same month Microsoft's DoH support for Windows Server DNS moved out of preview. Two announcements in the same month, both about encrypted DNS, and they point in different directions.
+The answer may indeed be 'not a lot', but I thought it was worth a clickbait headline from time to time. In March 2026, Quad9 announced support for DNS over QUIC (DoQ) alongside DoH3 on their public resolver network. That's the same month Microsoft's DoH support for Windows Server DNS moved out of preview. Two announcements in the same month, both about encrypted DNS, and they point in different directions.
 
 Microsoft's move continues the push toward DoH—encryption that hides in plain sight on port 443. Quad9's move adds DoQ, which offers better latency than DoT but keeps the port 853 visibility that enterprises actually want. Together they prompt a question I don't think the industry has properly answered yet: are we encrypting DNS for privacy, or for security? Because the answer changes everything about which protocol you should reach for.
 
-This post builds on my earlier work on [encrypted DNS governance](encrypted-dns.md) and [SVCB/HTTPS records](svcb-https-records.md). I'm not going to re-cover the wire format or the DoT vs DoH comparison—read those first if you need the background. This is about DoQ specifically, what QUIC brings to DNS, and why I think the enterprise conversation about encrypted DNS is asking the wrong question.
+This post builds on my earlier posts on [encrypted DNS governance](encrypted-dns.md) and [SVCB/HTTPS records](svcb-https-records.md). I'm not going to re-cover the wire format or the DoT vs DoH comparison—read those first if you need the background. This is about DoQ specifically, what QUIC brings to DNS, and why I think the enterprise conversation about encrypted DNS is asking the wrong question.
 
 <!-- truncate -->
-
----
 
 ## What QUIC Actually Is
 
@@ -28,23 +26,10 @@ Before talking about DoQ, it's worth being clear about what QUIC is—because it
 
 QUIC is a transport protocol designed from scratch with encryption as a first-class requirement, not an optional layer. It runs over UDP but provides the reliability, ordering, and congestion control you'd expect from TCP. The key distinction is that TLS isn't bolted on top of QUIC the way it is with TCP—the handshake is integrated. You can't have an unencrypted QUIC connection. Encryption is structural.
 
-```mermaid
-flowchart LR
-    subgraph TCP Stack
-        direction LR
-        A1[Application] --> B1[TLS] --> C1[TCP] --> D1[IP]
-    end
-    subgraph QUIC Stack
-        direction LR
-        A2[Application] --> B2["QUIC\n(TLS integrated)"] --> C2[UDP] --> D2[IP]
-    end
-```
 
 That integration matters for DNS because it collapses two separate negotiations—the TCP handshake and the TLS handshake—into one. TLS 1.3 over TCP costs 2 round trips before you can send application data. QUIC costs 1. For a protocol where every millisecond of the lookup adds to page load time, that's meaningful.
 
 QUIC also solves a problem that's plagued multiplexed protocols running over TCP: head-of-line blocking. When TCP loses a packet, everything queued behind it stalls until retransmission succeeds. HTTP/2 over TCP has this problem—you can have 50 requests multiplexed on one connection, but a single lost packet freezes all of them. QUIC handles loss at the stream level. If stream 5 loses a packet, streams 7 and 9 keep moving.
-
----
 
 ## DoQ: DNS-over-TCP's Logic, QUIC's Performance
 
@@ -76,7 +61,6 @@ sequenceDiagram
 
 The 0-RTT resumption story is where DoQ really separates itself from DoT. When a client has previously connected to a DoQ resolver, it stores a session token. On the next connection, it can send encrypted DNS data in the very first packet—before the server has responded at all. The resolver processes the query and the handshake simultaneously. For mobile clients that cycle through network connections frequently, that's not a theoretical win. It's a real reduction in lookup latency at exactly the moment users notice it most—when an app opens after switching from WiFi to cellular.
 
----
 
 ## What Quad9's Announcement Actually Means
 
@@ -90,7 +74,6 @@ First, DoQ now has a production resolver to test against at scale. Until now, Do
 
 Second, DDR (Discovery of Designated Resolvers, [RFC 9462](https://datatracker.ietf.org/doc/html/rfc9462)) becomes more interesting for DoQ. If you're already using Quad9 as your resolver, a DDR-capable client can now discover the DoQ endpoint automatically without manual configuration—the same mechanism I covered in detail in my [SVCB post](svcb-https-records.md). Clients that support both DDR and DoQ can upgrade transparently.
 
----
 
 ## The Protocol Landscape Now
 
@@ -123,7 +106,6 @@ The meaningful comparison for enterprise architects isn't DoT vs DoH any more—
 | Enterprise visibility | Yes | Yes | Needs interception |
 | Tooling maturity | High | Early | Medium |
 
----
 
 ## The Question Nobody's Asking
 
@@ -139,7 +121,6 @@ For a user on an untrusted network, confidentiality matters. Their ISP, their go
 
 For an enterprise, the threat model is different. You own the network between the client and your internal resolver. The risk isn't an observer on the wire—it's a compromised resolver returning poisoned responses, or malware using DNS for exfiltration and C2. Encryption doesn't address either of those. DNSSEC addresses the first. Visibility—the ability to see what's being queried—addresses the second.
 
----
 
 ## DNSSEC: The Security Property Enterprises Actually Need
 
@@ -169,7 +150,6 @@ But most enterprises don't run DNSSEC validation on their internal resolvers. Th
 
 The DNSSEC operational overhead is real—key rotation, larger response sizes due to RRSIG records, occasional validation failures that are painful to debug. But that overhead is lower than deploying and maintaining TLS interception infrastructure to inspect DoH traffic.
 
----
 
 ## Authentication vs Confidentiality in Practice
 
@@ -200,7 +180,6 @@ Deploying DoH internally gives you confidentiality on a hop you already control,
 
 I'd take DNSSEC validation on a plaintext resolver over DoH without DNSSEC validation, every time, for an internal enterprise deployment.
 
----
 
 ## What DoQ Changes for Enterprises
 
@@ -214,7 +193,6 @@ DoQ also has better characteristics for zone transfers. Zone content can be larg
 
 The tooling maturity gap is real—DoQ monitoring and inspection tools are considerably less developed than DoT equivalents. If you're considering DoQ for enterprise internal use today, factor in that your observability tooling may need to catch up.
 
----
 
 ## The Practical Upshot
 
@@ -225,14 +203,3 @@ Once that's in place, use DoT on the upstream forwarder hop—from your internal
 DoH belongs at the edge, not inside the perimeter. For users on untrusted networks—remote workers, mobile devices away from corporate infrastructure—DoH provides confidentiality from their local network observer. Inside your perimeter, it removes visibility for no additional security gain over DNSSEC + DoT.
 
 DoQ is worth watching for the upstream forwarder role, especially if you're running cloud-native or serverless workloads where connection churn is high. Quad9's production deployment means there's now a well-tested target to build against. Expect tooling to mature over the next 12-18 months.
-
----
-
-## Further Reading
-
-- [RFC 9250: DNS over QUIC](https://datatracker.ietf.org/doc/html/rfc9250)
-- [RFC 4033-4035: DNSSEC](https://datatracker.ietf.org/doc/html/rfc4033)
-- [RFC 9461: SVCB and HTTPS Records for DNS Servers](https://datatracker.ietf.org/doc/html/rfc9461)
-- [RFC 9462: Discovery of Designated Resolvers](https://datatracker.ietf.org/doc/html/rfc9462)
-- [My encrypted DNS post: DoH, DoT, enterprise visibility, and the FortiGate problem](encrypted-dns.md)
-- [My SVCB/HTTPS post: Service binding records, DDR, and how clients discover encrypted resolvers](svcb-https-records.md)

--- a/blog/dns-dot-doh-doq.md
+++ b/blog/dns-dot-doh-doq.md
@@ -31,11 +31,11 @@ QUIC is a transport protocol designed from scratch with encryption as a first-cl
 ```mermaid
 flowchart LR
     subgraph TCP Stack
-        direction TB
+        direction LR
         A1[Application] --> B1[TLS] --> C1[TCP] --> D1[IP]
     end
     subgraph QUIC Stack
-        direction TB
+        direction LR
         A2[Application] --> B2["QUIC\n(TLS integrated)"] --> C2[UDP] --> D2[IP]
     end
 ```


### PR DESCRIPTION
Adds a focused new post in the DNS series, building on the existing encrypted DNS and SVCB posts rather than repeating them.

**Focus areas:**
- DoQ and QUIC  what QUIC actually is and why integrating TLS into the transport mattersexplained 
- The DoT vs DoQ comparison (the new relevant comparison for enterprise architects)
- Quad9's DoQ production announcement and what it means practically for DDR and client library authors
- DNSSEC as authentication vs encryption as  the enterprise thesisconfidentiality 
- Why DNSSEC validation on internal resolvers is often more valuable than losing DNS visibility to DoH

**Mermaid diagrams:**
- Protocol stack comparison: TCP+TLS vs QUIC
- Handshake sequence: DoT cold start vs DoQ cold start
- Protocol evolution timeline
- Enterprise DNS architecture with DNSSEC and DoT/DoQ placement