### PR TITLE
Add Azure Blob Storage deployment

### DIFF
--- a/.github/workflows/merge_main.yml
+++ b/.github/workflows/merge_main.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy to S3
+name: Build and Deploy
 
 on:
   push:
@@ -45,3 +45,19 @@ jobs:
             --delete \
             --exclude ".git/*" \
             --exclude ".github/*"
+
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Sync to Azure Blob Storage
+        uses: azure/CLI@v2
+        with:
+          azcliversion: latest
+          inlineScript: |
+            az storage blob sync \
+              --source build/ \
+              --container '$web' \
+              --account-name ${{ secrets.AZURE_STORAGE_ACCOUNT }} \
+              --delete-destination true


### PR DESCRIPTION
Adds Azure Blob Storage as a second deployment target alongside S3.

## Changes
- Updated `merge_main.yml` to login to Azure and sync the build output to the `$web` container after the S3 sync

## Required secrets
Two new secrets must be added to the repo before this workflow will succeed:
- `AZURE_CREDENTIALS` — service principal JSON (`clientId`, `clientSecret`, `subscriptionId`, `tenantId`)
- `AZURE_STORAGE_ACCOUNT` — the storage account name