### PR TITLE
Enable automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,31 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - id: automerge
+        name: automerge
+        uses: "pascalgn/automerge-action@v0.16.4"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -16,7 +16,6 @@ on:
   check_suite:
     types:
       - completed
-  status: {}
 jobs:
   automerge:
     runs-on: ubuntu-latest

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -30,4 +30,4 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: "automerge"
           MERGE_METHOD: "merge"
-          MERGE_REQUIRED_APPROVALS: "0"
+          MERGE_REQUIRED_APPROVALS: "1"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -29,3 +29,6 @@ jobs:
         uses: "pascalgn/automerge-action@v0.16.4"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: "automerge"
+          MERGE_METHOD: "merge"
+          MERGE_REQUIRED_APPROVALS: "0"


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to enable automatic merging of pull requests under certain conditions. The workflow is triggered by various pull request events and uses the `pascalgn/automerge-action` to perform the automerge.

**Automation workflow addition:**

* Added a new workflow file `.github/workflows/automerge.yml` to set up automerging of pull requests using the `pascalgn/automerge-action` GitHub Action. The workflow is triggered by multiple pull request and status events and is configured with the necessary permissions and secrets.