### PR TITLE
fix: replace azure/CLI Docker action with native run step and retry logic

### DIFF
--- a/.github/workflows/merge_main.yml
+++ b/.github/workflows/merge_main.yml
@@ -52,12 +52,15 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Sync to Azure Blob Storage
-        uses: azure/CLI@v2
-        with:
-          azcliversion: latest
-          inlineScript: |
+        run: |
+          for attempt in 1 2 3; do
             az storage blob sync \
               --source build/ \
               --container '$web' \
               --account-name ${{ secrets.PROD_AZURE_STORAGE_ACCOUNT }} \
-              --delete-destination true
+              --delete-destination true && break
+            echo "Attempt $attempt failed, retrying in 15s..."
+            sleep 15
+          done
+        env:
+          AZCOPY_CONCURRENCY_VALUE: 10


### PR DESCRIPTION
AzCopy intermittently fails to transfer 1 file out of ~577, causing the job to exit with `CompletedWithErrors` and fail the whole deployment. This was the root cause of the recent CI failure.

The fix replaces the `azure/CLI@v2` Docker action with a plain `run` step. Azure CLI is pre-installed on `ubuntu-latest`, so spinning up a Docker container just to run `az` adds startup time for no benefit. Switching to a native step also makes it easy to wrap the command in a retry loop.

- Retries the sync up to 3 times with a 15s gap, so a single transient upload failure no longer kills the deployment
- Sets `AZCOPY_CONCURRENCY_VALUE: 10` to reduce pressure on the storage account during large syncs