### PR TITLE
Align DNS-AID examples with draft-02 FQDN shape

### DIFF
--- a/blog/dns-aid-agent-discovery.md
+++ b/blog/dns-aid-agent-discovery.md
@@ -45,15 +45,17 @@ DNS-AID does not invent a new naming system. It reuses DNS records and conventio
 
 ### Naming pattern
 
-The project uses a predictable namespace:
+The `-02` draft puts the canonical owner at a flat FQDN under the operator's zone:
 
-`_{agent-name}._{protocol}._agents.{your-domain}`
+`{agent-name}.{your-domain}`
 
 Examples:
 
-- `_chatbot._mcp._agents.example.com`
-- `_search._a2a._agents.example.com`
-- `_index._agents.example.com` for org-level discovery entry
+- `chatbot.example.com`
+- `search.example.com`
+- `_index._agents.example.com` for the org-level discovery entry (this one keeps the underscore convention)
+
+An optional walkable AliasMode is published at `{agent-name}._agents.{your-domain}` for crawlers and zone enumeration; it's an AliasMode SVCB record pointing back at the canonical flat name. The flat form is the canonical owner because `dNSName` SAN entries in publicly-issued x.509 certificates cannot contain underscores (per RFC 5280 / CA-Browser Forum BR preferred-name syntax in RFC 1034). The draft itself names this constraint in §3: *"the TargetName domain name MUST NOT contain underscores as public x.509 certificates will be used in communications."*
 
 ### Minimum record set from the IETF draft
 
@@ -109,8 +111,9 @@ dns-aid discover test.dns-aid.local --backend ddns
 And inspect DNS directly:
 
 ```bash
-dig SVCB _chatbot._mcp._agents.example.com
-dig TXT _index._agents.example.com
+dig SVCB chatbot.example.com                 # canonical flat owner
+dig SVCB chatbot._agents.example.com         # optional walkable AliasMode
+dig TXT  _index._agents.example.com          # org-level index
 ```
 
 ## 4) Trust model: what is proven, what is not
@@ -173,14 +176,14 @@ _index._agents.example.com. 300 IN TXT "chatbot:mcp,search:a2a"
 
 ### What protocol agnostic means in deployment
 
-Protocol agnostic means DNS-AID can carry endpoint metadata for MCP, A2A, HTTPS, or future protocols without changing the substrate. In practice, each protocol suite should be represented by a distinct SVCB record and ALPN set, for example:
+Protocol agnostic means DNS-AID can carry endpoint metadata for MCP, A2A, HTTPS, or future protocols without changing the substrate. Under `-02`, agent-protocol carriage moved into a new `bap` SvcParamKey so `alpn` returns to its RFC 9460 transport role. Each protocol suite is represented by a distinct SVCB record with `bap` naming the agent protocol and `alpn` carrying the TLS transport:
 
 ```dns
-agent-name.example.com. IN SVCB 1 . alpn="mcp,h2,h3"
-agent-name.example.com. IN SVCB 1 . alpn="a2a,h2"
+agent-name.example.com. IN SVCB 1 . alpn="h2,h3" bap="mcp"
+agent-name.example.com. IN SVCB 1 . alpn="h2"    bap="a2a"
 ```
 
-This lets clients choose protocol and endpoint URLs deterministically.
+This lets clients choose agent protocol and TLS transport independently. (`alpn=<agent-protocol>` alone is still permitted by the draft when only one protocol is supported.)
 
 ### How to avoid turning discovery into a data leak
 


### PR DESCRIPTION
Hey Simon — really nice post on DNS-AID, came across it researching for an ITU-T workshop. Noticed the spec citation references \`-02\` but the worked examples use the \`-01\` underscore-prefixed FQDN shape (\`_chatbot._mcp._agents.example.com\`).

The reason \`-02\` moved to a flat FQDN: a group of us working through deployment found that an underscored FQDN cannot appear as a \`dNSName\` SAN in an x.509 certificate — RFC 5280 / CA-Browser Forum BR's preferred-name syntax (RFC 1034) doesn't permit underscores in publicly-issued certs. That makes the \`-01\` shape unusable for any agent owner that wants a public TLS cert. The draft itself names the constraint in §3 (*"the TargetName domain name MUST NOT contain underscores as public x.509 certificates will be used in communications"*). So \`-02\` puts the canonical owner at a flat name (\`chatbot.example.com\`), keeps the underscored form only as an optional walkable AliasMode (\`chatbot._agents.example.com\`) that doesn't need its own cert, and moves agent-protocol carriage into a new \`bap\` SvcParamKey so \`alpn\` stays in its RFC 9460 transport role.

This PR does three small things, all sourced from \`-02\`:

1. Flips primary-owner examples from \`_{name}._{proto}._agents.{zone}\` to \`{name}.{zone}\` (§3.1).
2. Adds a one-paragraph mention of the optional walkable AliasMode at \`{name}._agents.{zone}\` (§3.2). The org-index name \`_index._agents.{zone}\` is unchanged — that one kept its underscore because its target points off-zone to a non-underscored host that can carry a SAN cert.
3. Changes \`alpn=mcp\` / \`alpn=a2a\` examples to \`alpn=h2 bap=mcp\` etc. Per the \`-02\` IANA request. (\`alpn=<protocol>\` alone is still permitted if only one protocol is supported.)

Happy to split into three smaller PRs if you'd prefer reviewing them separately. Reference for the \`-01\`→\`-02\` migration walked end-to-end: <https://www.darknetian.com/project/2026-05-12-dns-aid/>.