### PR TITLE
blog: add callbacks to Si's prior posts in this week's field notes

### DIFF
--- a/blog/encrypted-dns-leaks-and-azure-shipping-plumbing.md
+++ b/blog/encrypted-dns-leaks-and-azure-shipping-plumbing.md
@@ -23,7 +23,9 @@ The big one this week is a Help Net Security write-up of a [new arXiv paper](htt
 
 File this one under *encryption isn't the same as anonymity*. If you've been telling stakeholders "we're on DoH, we're fine" — you're mostly fine, for *contents*. The flow itself is still visible. Worth a read before your next privacy review.
 
-While we're here: Microsoft is finally bringing **DNS-over-HTTPS to Windows Server**. It's been on Windows client editions for a while, so this is hybrid-DNS catching up — useful, undramatic, the kind of thing that quietly shifts the on-prem baseline. ([TechSpot](https://www.techspot.com/news/112749-windows-server-getting-new-network-safety-capabilities-dns.html))
+Si has been making roughly this point in [his encrypted-DNS series](/blog/encrypted-dns) for a while now — *"encrypted between client and resolver doesn't mean invisible to security"* — and then sharpened it in [the DoT vs DoH vs DoQ piece](/blog/dns-dot-doh-doq) where he calls out that we keep conflating **confidentiality** (an observer on the wire) with **authentication** (DNSSEC) with **visibility** (your SIEM). The arXiv paper is, in effect, an empirical receipt for that argument: even when you've solved confidentiality of the *contents*, the *flow* is still observable enough to fingerprint with 77–86% accuracy. Si's framing predicted this; the researchers just measured it.
+
+While we're here: Microsoft is finally bringing **DNS-over-HTTPS to Windows Server**. It's been on Windows client editions for a while, so this is hybrid-DNS catching up — useful, undramatic, the kind of thing that quietly shifts the on-prem baseline. ([TechSpot](https://www.techspot.com/news/112749-windows-server-getting-new-network-safety-capabilities-dns.html)) Si covered the public-preview implications in detail back in February ([Encrypted DNS: what Microsoft's DoH public preview means for you](/blog/encrypted-dns)) — the GA news doesn't change the enterprise homework, it just makes it overdue.
 
 And a longer-lead heads-up: ICANN announced last month that the **DNS root KSK rollover** will happen on **11 October 2026**. If you operate validating resolvers or anything that pins trust anchors, get that in the calendar now. ([ICANN](https://www.icann.org/resources/press-material/release-2026-05-20-en))
 
@@ -47,7 +49,9 @@ AWS networking blog had a follow-up to last week's VPC resource gateways news: *
 
 Two things from the wider community this week.
 
-**Ivan Pepelnjak picked apart the AWS "Random Network Graph" data centre fabric paper** on the ipSpace blog. The marketing line is 33% better throughput, 69% fewer routers, 27% lower cost — and Ivan's measured take is *"is this the end of leaf-and-spine? Of course not."* He rediscovers the Plexxi ring-fabric lineage, points out that the AWS RNG is essentially an optimal expander with what they're calling "routing through randomness," and reminds us that you only get so far with unequal-cost multipathing before you need proper traffic engineering. If you've been wondering whether to throw out your two-tier spine, the answer is: no, but it's a fascinating read on what hyperscalers do once they're the only ones writing the rules. ([ipSpace](https://blog.ipspace.net/2026/06/goodbye-leaf-spine-networks/))
+**Ivan Pepelnjak picked apart the AWS "Random Network Graph" data centre fabric paper** on the ipSpace blog. The marketing line is 33% better throughput, 69% fewer routers, 27% lower cost — and Ivan's measured take is *"is this the end of leaf-and-spine? Of course not."* He rediscovers the Plexxi ring-fabric lineage, points out that the AWS RNG is essentially an optimal expander with what they're calling "routing through randomness," and reminds us that you only get so far with unequal-cost multipathing before you need proper traffic engineering. ([ipSpace](https://blog.ipspace.net/2026/06/goodbye-leaf-spine-networks/))
+
+Worth reading alongside Si's own take from a couple of weeks ago: [*Random by design: how AWS made expander-graph data centre fabrics work*](/blog/aws-random-graph-fabrics). His read is rather more enthusiastic — not that it's the end of leaf-and-spine for the rest of us, but that the *mental model* shifts from "design a perfect hierarchy" to "design for connectivity and let routing exploit it," and that for AWS-scale operators the expander pattern has "crossed from theory into mainstream practice." Ivan is sceptical of the breathless framing; Si is interested in what unlocked it (spraypoint routing, the optical layer, the operational tooling). They're not really disagreeing — they're standing at different ends of the same fabric. If you've been wondering whether to throw out your two-tier spine, the answer from both is: no. If you want to understand *why this works for AWS and probably not for you*, read both.
 
 **Cloudflare also had a short BGP wobble on the 17th.** Cloudflare Network Interconnect 2.0 customers saw BGP route-propagation issues for about 40 minutes from 11:34 UTC. Quick to identify, quick to fix, no real damage done. Worth noting because it lands in the same window as a much-shared retrospective doing the rounds about the February BYOIP outage — the one where a single empty-string API query erased about 25% of Cloudflare's BYOIP prefixes from global routing for six hours. Two very different incidents, but the Sohan Kanna write-up of February's failure is a tidy reminder that the internet's "phonebook" can be wiped by a misread query string. ([service alert](https://servicealert.ai/incident/cloudflare/dvrsxt4t6ts6) · [Feb post-mortem analysis](https://www.sohankanna.com/research/the-day-the-maps-went-blank-unpacking-the-cloudflare-byoip-bgp-outage-of-2026))
 
@@ -56,7 +60,7 @@ Two things from the wider community this week.
 - **The DNS privacy story is the one I'd bring to a meeting this week.** If you've been treating "we use DoH" as a settled answer, the metadata-leak paper is your homework. Not because it changes your immediate posture — but because *encryption ≠ unobservability* is a sentence that often needs saying.
 - **Azure's three little shipments are all hub-and-spoke maintenance.** Nothing flashy. But "ICMP on NAT Gateway v2" is the kind of thing the cable-monkeys among us will quietly love.
 - **The Cloudflare retrospective is worth your time even though it's months old.** Empty-string API queries deleting production routing is the sort of failure mode that should make every engineering org check their `if v != ""` guard rails one more time.
-- **And the AWS RNG paper is hype-shaped on the LinkedIn side and quietly interesting on the Ivan side.** Read both. If you only read one, read Ivan's.
+- **And the AWS RNG paper is hype-shaped on the LinkedIn side and quietly interesting on the Ivan side.** Read both. Then read Si's [*Random by design*](/blog/aws-random-graph-fabrics) for the "what actually unlocked it" angle — between the three you get sceptic, builder, and operator perspectives on the same fabric.
 
 ## Bookmarks
 
@@ -71,6 +75,9 @@ Two things from the wider community this week.
 - Goodbye, leaf-and-spine networks? — ipSpace.net — [link](https://blog.ipspace.net/2026/06/goodbye-leaf-spine-networks/)
 - Cloudflare CNI 2.0 BGP incident (Jun 17) — [link](https://servicealert.ai/incident/cloudflare/dvrsxt4t6ts6)
 - The day the maps went blank: Cloudflare BYOIP retrospective — Sohan Kanna — [link](https://www.sohankanna.com/research/the-day-the-maps-went-blank-unpacking-the-cloudflare-byoip-bgp-outage-of-2026)
+- Si — [Encrypted DNS: what Microsoft's DoH public preview means for you](/blog/encrypted-dns) (Feb 2026)
+- Si — [Quad9 now supports DoQ along with DoH3 — DoT vs DoH vs DoQ](/blog/dns-dot-doh-doq) (Apr 2026)
+- Si — [Random by design: how AWS made expander-graph data centre fabrics work](/blog/aws-random-graph-fabrics) (Jun 2026)
 
 ---
 


### PR DESCRIPTION
Retro-edit of last week's field notes (PR #432, merged) to weave in callbacks to Si's own back-catalogue, as agreed.

## What changed

One file: `blog/encrypted-dns-leaks-and-azure-shipping-plumbing.md`.

Three thematic callbacks added:

1. **DNS metadata-leak paper** \u2192 links to Si's [encrypted-dns](/blog/encrypted-dns) post (Feb 2026) and [dns-dot-doh-doq](/blog/dns-dot-doh-doq) (Apr 2026). The arXiv paper is, in effect, empirical confirmation of Si's earlier framing that we keep conflating confidentiality, authentication, and visibility \u2014 the new measurements validate the argument.
2. **Windows Server DoH GA** \u2192 links to Si's Feb 2026 public-preview deep dive. The enterprise homework was already laid out then; this is just GA.
3. **AWS Random Network Graph** \u2192 pairs Ivan Pepelnjak's sceptical ipSpace take with Si's more enthusiastic [aws-random-graph-fabrics](/blog/aws-random-graph-fabrics) (Jun 2026). Framed as 'different ends of the same fabric' rather than manufactured controversy \u2014 Ivan is sceptical of the framing, Si is interested in what unlocked it. Both agree it's not the end of leaf-and-spine for the rest of us.

Bookmarks section also gains three 'Further reading' entries linking to those posts.

## Why

Si asked the weekly-roundup skill to surface his prior coverage where it earns its place, and to honestly flag where a newer post might disagree. SKILL.md updated separately for future runs; this PR retro-fits last week's post.

## Conventions

- No facts changed. Voice and structure preserved.
- All three internal slugs verified to exist on `main`.
- Tags/frontmatter untouched.

Don't merge without your eyes on it.

\u2014 Huck 📝