### PR TITLE
Add inclusive language guidance to Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,6 +54,24 @@ Avoid formal or overly academic phrases such as:
 - Include Mermaid diagrams to visualize concepts where appropriate.
 - Support claims with specific data and statistics whenever possible.
 
+## Inclusive Language Rules
+- Use gender-neutral language by default (for example, "they", "everyone", "folks", "team").
+- Avoid assumptions about age, gender, ethnicity, disability, religion, culture, or family structure.
+- Use people-first language unless a group clearly prefers identity-first language.
+- Prefer globally clear wording over local idioms, slang, or culture-specific references.
+- Describe requirements and behaviours, not personal traits.
+- If user wording may exclude people, suggest a neutral rewrite.
+
+### Preferred alternatives
+- "guys" -> "everyone" or "team"
+- "manpower" or "man-hours" -> "effort", "staffing", or "person-hours"
+- "sanity check" -> "quick check" or "sense check"
+- "normal user" -> "typical user" or "most users"
+- "master/slave" -> "primary/secondary", "leader/follower", or protocol-specific terms
+- "blacklist/whitelist" -> "denylist/allowlist" or "blocklist/allowlist"
+- "dummy value" -> "placeholder value"
+- "grandfathered" -> "legacy status"
+
 ## Blog Post Tagging
 
 Every post must have **at most 3 tags**, chosen from `blog/tags.yml`.


### PR DESCRIPTION
## Why
The instructions already define tone and style, but they did not explicitly steer wording toward inclusive language. This change adds clear guidance so generated content is more respectful and consistent for a broad audience.

## What changed
- Added a new `Inclusive Language Rules` section in `.github/copilot-instructions.md`.
- Added practical rules for neutral language, avoiding demographic assumptions, people-first wording, and globally clear phrasing.
- Added a `Preferred alternatives` list for common terms to avoid, with inclusive replacements.

## Notes for reviewers
This is a documentation-only update to Copilot guidance and does not change runtime behaviour.