### PR TITLE
Fix duplicate `cold-open` heading IDs on `/tags/aws`

### DIFF
--- a/blog/quiet-week-cloud-wan-routing-policy-post-quantum-clock.md
+++ b/blog/quiet-week-cloud-wan-routing-policy-post-quantum-clock.md
@@ -15,12 +15,13 @@ date: 2026-06-28
 
 ---
 
+The internet packed a sandwich and went outside this week.
+
 <!-- truncate -->
 
 ## Cold open
 
-The internet packed a sandwich and went outside this week. Azure's networking blog is unchanged since the 19th, Ivan over at ipSpace has gone on summer break, and the only mildly newsworthy DNS story is the same encrypted-DNS metadata-leak paper I covered last week. So this is a slim one — but the AWS Cloud WAN routing-policy series got its Part 2, and the White House quietly handed everyone a 2030 deadline for post-quantum crypto. Both are worth your Monday morning.
-
+Azure's networking blog is unchanged since the 19th, Ivan over at ipSpace has gone on summer break, and the only mildly newsworthy DNS story is the same encrypted-DNS metadata-leak paper I covered last week. So this is a slim one — but the AWS Cloud WAN routing-policy series got its Part 2, and the White House quietly handed everyone a 2030 deadline for post-quantum crypto. Both are worth your Monday morning.
 ## DNS desk
 
 Genuinely nothing new of substance this week. The CIRA/ISOC reading list is still pushing last week's "deploy DNSSEC and RPKI already" agenda, and the ICANN KSK rollover ([11 October 2026](https://www.icann.org/resources/press-material/release-2026-05-20-en)) is still on the calendar where I left it last Sunday.

--- a/blog/quiet-week-cloud-wan-routing-policy-post-quantum-clock.md
+++ b/blog/quiet-week-cloud-wan-routing-policy-post-quantum-clock.md
@@ -15,11 +15,11 @@ date: 2026-06-28
 
 ---
 
+<!-- truncate -->
+
 ## Cold open
 
 The internet packed a sandwich and went outside this week. Azure's networking blog is unchanged since the 19th, Ivan over at ipSpace has gone on summer break, and the only mildly newsworthy DNS story is the same encrypted-DNS metadata-leak paper I covered last week. So this is a slim one — but the AWS Cloud WAN routing-policy series got its Part 2, and the White House quietly handed everyone a 2030 deadline for post-quantum crypto. Both are worth your Monday morning.
-
-<!-- truncate -->
 
 ## DNS desk
 

--- a/blog/tgw-cloudwan-mcp-expressroute-revisited-ipspace-returns.md
+++ b/blog/tgw-cloudwan-mcp-expressroute-revisited-ipspace-returns.md
@@ -16,12 +16,13 @@ date: 2026-07-05
 
 ---
 
+Two weeks ago I was mildly excited that AWS Cloud WAN had grown up enough to have proper BGP attributes.
+
 <!-- truncate -->
 
 ## Cold open
 
-Two weeks ago I was mildly excited that AWS Cloud WAN had grown up enough to have proper BGP attributes. This week AWS have gone one further and shipped a migration guide that uses Terraform for the plumbing and an MCP server for the validation. Meanwhile Jose over at Cloudtrooper has re-written the ExpressRoute routing playbook for the Virtual WAN era, Ivan came back from summer break with an EVPN lab in his suitcase, and Cloudflare had "Content Independence Day" — which turns out to be less about DNS than the name suggests.
-
+This week AWS have gone one further and shipped a migration guide that uses Terraform for the plumbing and an MCP server for the validation. Meanwhile Jose over at Cloudtrooper has re-written the ExpressRoute routing playbook for the Virtual WAN era, Ivan came back from summer break with an EVPN lab in his suitcase, and Cloudflare had "Content Independence Day" — which turns out to be less about DNS than the name suggests.
 ## DNS desk
 
 Genuinely nothing new in the DNS trenches this week. The [ICANN KSK rollover](https://www.icann.org/resources/press-material/release-2026-05-20-en) is still pencilled in for 11 October 2026 and the coverage this week (Advanced Television, Computing, PRNewswire) is just the same May press release doing the rounds. If you deploy resolvers, [RFC 5011](https://datatracker.ietf.org/doc/html/rfc5011) is still your friend.

--- a/blog/tgw-cloudwan-mcp-expressroute-revisited-ipspace-returns.md
+++ b/blog/tgw-cloudwan-mcp-expressroute-revisited-ipspace-returns.md
@@ -16,11 +16,11 @@ date: 2026-07-05
 
 ---
 
+<!-- truncate -->
+
 ## Cold open
 
 Two weeks ago I was mildly excited that AWS Cloud WAN had grown up enough to have proper BGP attributes. This week AWS have gone one further and shipped a migration guide that uses Terraform for the plumbing and an MCP server for the validation. Meanwhile Jose over at Cloudtrooper has re-written the ExpressRoute routing playbook for the Virtual WAN era, Ivan came back from summer break with an EVPN lab in his suitcase, and Cloudflare had "Content Independence Day" — which turns out to be less about DNS than the name suggests.
-
-<!-- truncate -->
 
 ## DNS desk
 


### PR DESCRIPTION
## Why
The `/tags/aws` page had a WCAG 2 AA violation for duplicate `id` values (`#cold-open`). Multiple posts shared the `## Cold open` heading, and those heading IDs appeared together in the tag page excerpts.

## What changed
This moves the `<!-- truncate -->` marker to before the `## Cold open` heading in the two AWS-tagged field-notes posts that appear on the page:

- `blog/quiet-week-cloud-wan-routing-policy-post-quantum-clock.md`
- `blog/tgw-cloudwan-mcp-expressroute-revisited-ipspace-returns.md`

With the truncate marker before that heading, the excerpt content no longer includes that heading ID, so the rendered `/tags/aws` page no longer contains duplicate `cold-open` IDs.

## Notes
This is a content-only fix that avoids changing theme or rendering logic.