### PR TITLE
Fix NSP walkthrough on standard service endpoint post (follow-up to #472)

### DIFF
--- a/updates/in-preview-public-preview-standard-service-endpoint.md
+++ b/updates/in-preview-public-preview-standard-service-endpoint.md
@@ -5,6 +5,8 @@ tags:
   - private-link
   - azure
   - networks
+  - service-endpoints
+  - network-security-perimeter
 date: 2026-07-25
 ---
 
@@ -139,15 +141,29 @@ az network perimeter create \
   --name my-nsp \
   --location eastus2
 
-# Add inbound rule matching the network identifier prefix
+# Create a profile inside the perimeter
+az network perimeter profile create \
+  --resource-group my-rg \
+  --perimeter-name my-nsp \
+  --name my-profile
+
+# Grab the public IP prefix range that owns the network identifier
+PREFIX=$(az network public-ip prefix show \
+  --resource-group my-rg \
+  --name service-ep-prefix \
+  --query ipPrefix --output tsv)
+
+# Add inbound rule allowing the whole public IP prefix range
 az network perimeter profile access-rule create \
   --resource-group my-rg \
   --perimeter-name my-nsp \
   --profile-name my-profile \
-  --name allow-service-endpoint \
+  --access-rule-name allow-service-endpoint \
   --direction Inbound \
-  --address-prefixes "203.0.113.10/32"
+  --address-prefixes "[$PREFIX]"
 ```
+
+Allowing the public IP *prefix range* rather than a hard-coded `/32` matches Microsoft's Learn walkthrough and means you don't have to update the NSP rule if you later add another identifier from the same prefix.
 
 Once associated, the PaaS resource accepts service endpoint traffic from any subnet tagged with that identifier.
 


### PR DESCRIPTION
Follow-up to Copilot's review on #472 (already merged).

Copilot flagged two real issues in the NSP walkthrough plus a tag count mismatch. This PR fixes them:

- **Missing profile create step** — the walkthrough referenced `--profile-name my-profile` without ever creating the profile. Added the `az network perimeter profile create` step.
- **`--access-rule-name` vs `--name`** — aligned with the [Learn CLI reference](https://learn.microsoft.com/en-us/cli/azure/network/perimeter/profile/access-rule?view=azure-cli-latest#az-network-perimeter-profile-access-rule-create) (both technically work, but `--access-rule-name` matches the docs).
- **Public IP prefix range instead of a hard-coded /32** — resolves the prefix from the public IP prefix resource we already created, so the rule allows the whole range Microsoft's Learn example uses. No manual IP hardcoding.
- **Extra tags** — added `service-endpoints` and `network-security-perimeter` so the post has 5 tags (issue asked for 4–8).

/cc @copilot