### PR TITLE
Remove article copy markdown button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -67,13 +67,6 @@ const config = {
   clientModules: [require.resolve('./src/scripts/mermaid_icons.js')],
 
   plugins: [
-    [
-      'docusaurus-plugin-copy-page-button',
-      {
-        placement: 'article',
-        enabledActions: ['copy', 'view'],
-      },
-    ],
     function suppressVscodeLanguageServerTypesWarning() {
       return {
         name: 'suppress-vscode-languageserver-types-warning',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@iconify-json/logos": "^1.2.9",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
-        "docusaurus-plugin-copy-page-button": "^0.8.4",
         "lodash-es": "^4.18.1",
         "prism-react-renderer": "^2.3.0",
         "react": "^18.0.0",
@@ -8946,19 +8945,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/docusaurus-plugin-copy-page-button": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.8.4.tgz",
-      "integrity": "sha512-OBWmUEFIqR3BJ5giae6D518b69ZfZQ5HKrazrY2IPA6tDNX2F3m1ejeyE0oqcVcE7GVkE+K0+vJ5T+kIos8u1w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/core": "^3.0.0",
-        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/dom-converter": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@iconify-json/logos": "^1.2.9",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
-    "docusaurus-plugin-copy-page-button": "^0.8.4",
     "lodash-es": "^4.18.1",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.0.0",


### PR DESCRIPTION
## Why
I removed the article copy markdown button because it is no longer wanted in the blog post UI.

## What changed
- Removed the `docusaurus-plugin-copy-page-button` plugin configuration from `docusaurus.config.js`.
- Removed `docusaurus-plugin-copy-page-button` from `package.json` dependencies.
- Updated `package-lock.json` to reflect the dependency removal.

## Notes
This is a behaviour change only for the post action UI. Content rendering and site structure are unchanged.