### PR TITLE
Blog post: Azure Virtual Network Routing Appliance goes GA

### DIFF
--- a/blog/azure-virtual-network-appliance.md
+++ b/blog/azure-virtual-network-appliance.md
@@ -104,13 +104,13 @@ flowchart TB
     subgraph Hub["Hub VNet"]
         FW["Azure Firewall"]
         GW["VPN/ER Gateway"]
-        AVNA["Virtual Network<br/>Appliance"]
-        subgraph AVNART["AVNA Route Table"]
-            AVNART1["Learned Routes<br/>to Spokes"]
+        VNRA["Virtual Network<br/>Appliance"]
+        subgraph VNRART["VNRA Route Table"]
+            VNRART1["Learned Routes<br/>to Spokes"]
         end
     end
     
-    AVNA -.-> AVNART
+    VNRA -.-> VNRART
     
     subgraph SpokeA["Spoke A VNet"]
         subgraph SubnetA1["Workload Subnet A"]
@@ -120,7 +120,7 @@ flowchart TB
             direction LR
             RTA1["Default Route<br/>(Firewall)"]
             RTA2["On Premise Prefixes<br/>(Gateway)"]
-            RTA3["Cloud Prefixes<br/>(AVNA)"]
+            RTA3["Cloud Prefixes<br/>(VNRA)"]
         end
     end
     
@@ -132,7 +132,7 @@ flowchart TB
             direction LR
             RTB1["Default Route<br/>(Firewall)"]
             RTB2["On Premise Prefixes<br/>(Gateway)"]
-            RTB3["Cloud Prefixes<br/>(AVNA)"]
+            RTB3["Cloud Prefixes<br/>(VNRA)"]
         end
     end
     
@@ -141,17 +141,17 @@ flowchart TB
     
     RTA1 --> FW
     RTA2 --> GW
-    RTA3 --> AVNA
+    RTA3 --> VNRA
     RTB1 --> FW
     RTB2 --> GW
-    RTB3 --> AVNA
+    RTB3 --> VNRA
     
     FW -->|"Internet<br/>Egress"| Internet((Internet))
     GW -->|"ExpressRoute/<br/>VPN"| OnPrem((On-Premise))
     
     style FW fill:#e74c3c,color:#fff
     style GW fill:#9b59b6,color:#fff
-    style AVNA fill:#3498db,color:#fff
+    style VNRA fill:#3498db,color:#fff
     style VMA fill:#27ae60,color:#fff
     style VMB fill:#27ae60,color:#fff
     style Internet fill:#95a5a6,color:#fff
@@ -159,7 +159,7 @@ flowchart TB
 ```
 The alternative is to send all traffic to the appliance and then have the subnet it lives in route to on premise, internet or other spokes, which would be a lot easier to manage; however, the appliance currently has no capability to route to the internet, even if you put a NAT gateway for the appliance subnet. I tried it so you don't have to!
 
-The halfway house is to have RFC1918 routes going to the appliance, which sorts out what goes on premise and what goes to another spoke, and then have the default route going to your egress solution. This is a bit more work to set up and manage but it does give you the best of both worlds in terms of control and simplicity. Separating cloud from on premise routes in the AVNA should be fairly straightforward because all the spoke routes will be learned in the hub automagically and everything else in 10/8 can go to your gateway.
+The halfway house is to have RFC1918 routes going to the appliance, which sorts out what goes on premise and what goes to another spoke, and then have the default route going to your egress solution. This is a bit more work to set up and manage but it does give you the best of both worlds in terms of control and simplicity. Separating cloud from on premise routes in the VNRA should be fairly straightforward because all the spoke routes will be learned in the hub automagically and everything else in 10/8 can go to your gateway.
 
 ```mermaid
 flowchart TB
@@ -168,10 +168,10 @@ flowchart TB
     subgraph Hub["Hub VNet"]
         FW["Azure Firewall"]
         GW["VPN/ER Gateway"]
-        AVNA["Virtual Network<br/>Appliance"]
-        subgraph AVNART["AVNA Route Table"]
-            AVNART1["On Premise Prefixes<br/>(Gateway)"]
-            AVNART2["Learned Routes<br/>to Spokes"]
+        VNRA["Virtual Network<br/>Appliance"]
+        subgraph VNRART["VNRA Route Table"]
+            VNRART1["On Premise Prefixes<br/>(Gateway)"]
+            VNRART2["Learned Routes<br/>to Spokes"]
         end
     end
     
@@ -182,7 +182,7 @@ flowchart TB
         subgraph RTA["Route Table"]
             direction LR
             RTA1["Default Route<br/>(Firewall)"]
-            RTA2["RFC1918 Prefixes<br/>(AVNA)"]
+            RTA2["RFC1918 Prefixes<br/>(VNRA)"]
         end
     end
     
@@ -193,7 +193,7 @@ flowchart TB
         subgraph RTB["Route Table"]
             direction LR
             RTB1["Default Route<br/>(Firewall)"]
-            RTB2["RFC1918 Prefixes<br/>(AVNA)"]
+            RTB2["RFC1918 Prefixes<br/>(VNRA)"]
         end
     end
     
@@ -201,19 +201,19 @@ flowchart TB
     SubnetB1 -.-> RTB
     
     RTA1 --> FW
-    RTA2 --> AVNA
+    RTA2 --> VNRA
     RTB1 --> FW
-    RTB2 --> AVNA
+    RTB2 --> VNRA
     
-    AVNA -.-> AVNART
-    AVNART1 --> GW
+    VNRA -.-> VNRART
+    VNRART1 --> GW
     
     FW -->|"Internet<br/>Egress"| Internet((Internet))
     GW -->|"ExpressRoute/<br/>VPN"| OnPrem((On-Premise))
     
     style FW fill:#e74c3c,color:#fff
     style GW fill:#9b59b6,color:#fff
-    style AVNA fill:#3498db,color:#fff
+    style VNRA fill:#3498db,color:#fff
     style VMA fill:#27ae60,color:#fff
     style VMB fill:#27ae60,color:#fff
     style Internet fill:#95a5a6,color:#fff

--- a/blog/azure-virtual-network-routing-appliance-ga.md
+++ b/blog/azure-virtual-network-routing-appliance-ga.md
@@ -21,7 +21,7 @@ Azure now has a managed routing layer for hub-and-spoke traffic that is built fo
 
 The preview version of this article covered the basic shape of the service: a resource that lives in a hub VNet, forwards private traffic between spokes, and sits somewhere between Azure Firewall and a third-party NVA.
 
-I made the same mistake many did in assuming this followed the same model as many other Azure services: a glorified NVA in a load balancer sandwich. [Jose Moreno's post](https://blog.cloudtrooper.net/2026/03/07/what-is-the-azure-virtual-network-routing-appliance/) on the architecture of VNRA was a revelation, and he knows more about what is under the hood than most.
+I made the same mistake as many did in assuming this followed the same model as many other Azure services: a glorified NVA in a load balancer sandwich. [Jose Moreno's post](https://blog.cloudtrooper.net/2026/03/07/what-is-the-azure-virtual-network-routing-appliance/) on the architecture of VNRA was a revelation, and he knows more about what is under the hood than most.
 
 The rest of the post still holds. The GA release mostly fills in the gaps.
 

--- a/blog/azure-virtual-network-routing-appliance-ga.md
+++ b/blog/azure-virtual-network-routing-appliance-ga.md
@@ -21,9 +21,9 @@ Azure now has a managed routing layer for hub-and-spoke traffic that is built fo
 
 The preview version of this article covered the basic shape of the service: a resource that lives in a hub VNet, forwards private traffic between spokes, and sits somewhere between Azure Firewall and a third-party NVA.
 
-I made the same mistake many did in assuming this followed the same model as many other Azure services: a glorifed NVA in a loadbalancer sandwich. [Jose Moreno's post](https://blog.cloudtrooper.net/2026/03/07/what-is-the-azure-virtual-network-routing-appliance/) on the architecture of VNRA was a revelation: and he knows more about what's under the hood than most.
+I made the same mistake many did in assuming this followed the same model as many other Azure services: a glorified NVA in a load balancer sandwich. [Jose Moreno's post](https://blog.cloudtrooper.net/2026/03/07/what-is-the-azure-virtual-network-routing-appliance/) on the architecture of VNRA was a revelation, and he knows more about what is under the hood than most.
 
-That rest of the post still holds. The GA release mostly fills in the gaps.
+The rest of the post still holds. The GA release mostly fills in the gaps.
 
 ## What changed at GA
 
@@ -36,7 +36,7 @@ That rest of the post still holds. The GA release mostly fills in the gaps.
 
 ## Why Cloudtrooper's take matters
 
-Jose Moreno's post is, unsuprisingly, the best architectural explanation I have seen so far. He frames VNRA as a managed SDN forwarding layer, not just some VMs balancing on each other in a trench coat.
+Jose Moreno's post is, unsurprisingly, the best architectural explanation I have seen so far. He frames VNRA as a managed SDN forwarding layer, not just some VMs balancing on each other in a trench coat.
 
 That distinction matters because it explains why the service is fast, why the control model is Azure-native, and why I should not expect firewall-style features from it.
 
@@ -61,4 +61,32 @@ I would not use it when I need:
 
 The main question is no longer "what is this?" It is "where does this fit in a hub design I already trust?"
 
-Now that VNRA is GA, the architectual patterns need to be revised to reflect this as a base unit of routing in large hub-and-spoke designs. It has become a matter of fact that firewalls sit in the hub, mainly because there wasn't a lot of other options. VNRA changes that, and it is worth thinking about how to use it in a way that does not compromise the role of the firewall.
+Now that VNRA is GA, the architectural patterns need to be revised to reflect this as a base unit of routing in large hub-and-spoke designs. Firewalls sit in many hubs because there has not been a better native routing option. VNRA changes that, and it is worth thinking about how to use it in a way that does not compromise the role of the firewall.
+
+## What I tested in the lab
+
+I did some lab work to validate the line from the preview post that VNRA does not route non-RFC1918 traffic in the way many of us might hope.
+
+The lab was simple: one hub, three spokes, an Azure Firewall in the hub, and a VNRA in the same hub. First I pointed `10.0.0.0/8` at the VNRA so spoke-to-spoke traffic would use the high-speed forwarding path. I then pointed `0.0.0.0/0` at Azure Firewall for public egress. That worked exactly as expected.
+
+I then tried the more tempting design. I pointed `0.0.0.0/0` from the spokes to the VNRA, and on the VNRA subnet I added a further `0.0.0.0/0` route to Azure Firewall. The idea was neat enough on paper: send everything to VNRA, let it deal with local traffic, then hand internet-bound traffic to the firewall.
+
+That does not work.
+
+So the practical design rule still looks the same to me. Use VNRA for private east-west routing, and keep internet egress on the firewall or whatever egress service you already trust. If you try to turn VNRA into a universal first hop for both private and public traffic, you run out of road.
+
+## What I would do
+
+If I were building this today, I would keep the split-brain design on purpose:
+
+- send private address space to VNRA;
+- send the default route to the firewall;
+- let each service do one job well.
+
+That is less tidy on a whiteboard, but it matches how the platform behaves.
+
+## Verdict
+
+GA has not changed the core story. VNRA is a strong addition to Azure hub design because it gives me a native, high-speed forwarding layer without asking a firewall to pretend to be a router.
+
+It is not an egress device, probably never will be (or should be), and my lab work backs that up.

--- a/blog/azure-virtual-network-routing-appliance-ga.md
+++ b/blog/azure-virtual-network-routing-appliance-ga.md
@@ -6,7 +6,6 @@ tags:
   - performance
   - ipv6
 date: 2026-08-10
-draft: true
 ---
 
 Azure Virtual Network Routing Appliance has moved from [awkward public preview](azure-virtual-network-appliance.md) to general availability. That matters because the preview post left a few open questions: how it would be priced, whether metrics would exist, how much capacity it could really take, and whether it was even remotely ready for production use.

--- a/blog/azure-virtual-network-routing-appliance-ga.md
+++ b/blog/azure-virtual-network-routing-appliance-ga.md
@@ -5,11 +5,11 @@ tags:
   - azure
   - performance
   - ipv6
-date: 2026-08-05
+date: 2026-08-10
 draft: true
 ---
 
-Azure Virtual Network Routing Appliance has moved from awkward public preview to general availability. That matters because the preview post left a few open questions: how it would be priced, whether metrics would exist, how much capacity it could really take, and whether it was even remotely ready for production use.
+Azure Virtual Network Routing Appliance has moved from [awkward public preview](azure-virtual-network-appliance.md) to general availability. That matters because the preview post left a few open questions: how it would be priced, whether metrics would exist, how much capacity it could really take, and whether it was even remotely ready for production use.
 
 <!--truncate-->
 

--- a/blog/azure-virtual-network-routing-appliance-ga.md
+++ b/blog/azure-virtual-network-routing-appliance-ga.md
@@ -20,7 +20,7 @@ Azure now has a managed routing layer for hub-and-spoke traffic that is built fo
 
 ## What I wrote in the preview post
 
-The preview version of this article covered the basic shape of the service: a resource that lives in a hub VNet, forwards private traffic between spokes, and sits somewhere between Azure Firewall and a third-party NVA.
+The [preview version of this article](azure-virtual-network-appliance.md) covered the basic shape of the service: a resource that lives in a hub VNet, forwards private traffic between spokes, and sits somewhere between Azure Firewall and a third-party NVA.
 
 I made the same mistake as many did in assuming this followed the same model as many other Azure services: a glorified NVA in a load balancer sandwich. [Jose Moreno's post](https://blog.cloudtrooper.net/2026/03/07/what-is-the-azure-virtual-network-routing-appliance/) on the architecture of VNRA was a revelation, and he knows more about what is under the hood than most.
 

--- a/blog/azure-virtual-network-routing-appliance-ga.md
+++ b/blog/azure-virtual-network-routing-appliance-ga.md
@@ -1,0 +1,64 @@
+---
+title: Azure Virtual Network Routing Appliance goes GA
+authors: simonpainter
+tags:
+  - azure
+  - performance
+  - ipv6
+date: 2026-08-05
+draft: true
+---
+
+Azure Virtual Network Routing Appliance has moved from awkward public preview to general availability. That matters because the preview post left a few open questions: how it would be priced, whether metrics would exist, how much capacity it could really take, and whether it was even remotely ready for production use.
+
+<!--truncate-->
+
+## TL;DR
+
+Azure now has a managed routing layer for hub-and-spoke traffic that is built for throughput, not inspection. I would treat it as the right answer when I need high-bandwidth east-west routing in the hub and I do not need firewall features in the data path.
+
+## What I wrote in the preview post
+
+The preview version of this article covered the basic shape of the service: a resource that lives in a hub VNet, forwards private traffic between spokes, and sits somewhere between Azure Firewall and a third-party NVA.
+
+I made the same mistake many did in assuming this followed the same model as many other Azure services: a glorifed NVA in a loadbalancer sandwich. [Jose Moreno's post](https://blog.cloudtrooper.net/2026/03/07/what-is-the-azure-virtual-network-routing-appliance/) on the architecture of VNRA was a revelation: and he knows more about what's under the hood than most.
+
+That rest of the post still holds. The GA release mostly fills in the gaps.
+
+## What changed at GA
+
+- Production support is now explicit.
+- Bandwidth tiers are fixed at creation time.
+- Azure Monitor metrics now exist by default.
+- IPv4, IPv6, and dual-stack VNets are supported.
+- The supported region list is now published.
+- Built-in high availability and availability zone resilience are part of the story.
+
+## Why Cloudtrooper's take matters
+
+Jose Moreno's post is, unsuprisingly, the best architectural explanation I have seen so far. He frames VNRA as a managed SDN forwarding layer, not just some VMs balancing on each other in a trench coat.
+
+That distinction matters because it explains why the service is fast, why the control model is Azure-native, and why I should not expect firewall-style features from it.
+
+## When I would use it
+
+I would reach for VNRA when I want:
+
+- spoke-to-spoke routing at scale;
+- simpler east-west routing than a pile of UDRs and hand-built NVAs;
+- IPv6 support in the hub;
+- a forwarding layer that does not need to inspect traffic.
+
+## When I would not use it
+
+I would not use it when I need:
+
+- stateful L7 inspection;
+- internet egress or NAT;
+- a single box to do routing and filtering together.
+
+## The design question
+
+The main question is no longer "what is this?" It is "where does this fit in a hub design I already trust?"
+
+Now that VNRA is GA, the architectual patterns need to be revised to reflect this as a base unit of routing in large hub-and-spoke designs. It has become a matter of fact that firewalls sit in the hub, mainly because there wasn't a lot of other options. VNRA changes that, and it is worth thinking about how to use it in a way that does not compromise the role of the firewall.

--- a/blog/azure-virtual-network-routing-appliance-ga.md
+++ b/blog/azure-virtual-network-routing-appliance-ga.md
@@ -11,6 +11,8 @@ draft: true
 
 Azure Virtual Network Routing Appliance has moved from [awkward public preview](azure-virtual-network-appliance.md) to general availability. That matters because the preview post left a few open questions: how it would be priced, whether metrics would exist, how much capacity it could really take, and whether it was even remotely ready for production use.
 
+If you want the shorter news version first, I also wrote up the launch notes in [Generally Available: Azure Virtual Network routing appliance](/updates/launched-generally-available-azure-virtual-network-routing-appliance).
+
 <!--truncate-->
 
 ## TL;DR

--- a/updates/launched-generally-available-azure-virtual-network-routing-appliance.md
+++ b/updates/launched-generally-available-azure-virtual-network-routing-appliance.md
@@ -23,6 +23,8 @@ Because it runs on specialised hardware rather than general-purpose VMs, you get
 
 The official announcement is here: [Generally Available: Azure Virtual Network routing appliance](https://azure.microsoft.com/updates?id=568605). The how-to guide is on Microsoft Learn: [Create a Routing Appliance - Azure Virtual Network](https://learn.microsoft.com/en-us/azure/virtual-network/how-to-create-virtual-network-routing-appliance).
 
+If you want the longer version, I wrote up a fuller take on what changed at GA, where it fits in a hub design, and why I still would not use it for internet egress in [Azure Virtual Network Routing Appliance goes GA](/blog/azure-virtual-network-routing-appliance-ga).
+
 ## Who should care
 
 If you run a hub-and-spoke design with heavy east-west traffic between spokes, this matters. The appliance gives you a scalable transit point without stitching together load balancers and NVA scale sets.


### PR DESCRIPTION
This pull request adds a new blog post draft, "Azure Virtual Network Routing Appliance goes GA," which discusses the general availability release of Azure's managed routing appliance. The post summarizes the key changes from the preview version, explains the service's architectural role, and provides practical guidance on when and how to use it in Azure hub-and-spoke network designs.

**New blog post content:**

- Added a draft blog post (`blog/azure-virtual-network-routing-appliance-ga.md`) covering the GA release of Azure Virtual Network Routing Appliance, including its features, use cases, and design considerations.
- The post highlights major updates at GA, such as production support, fixed bandwidth tiers, Azure Monitor metrics, IPv6 support, published region list, and built-in high availability.
- Provides practical advice for using the routing appliance, including scenarios where it is and is not appropriate, and lab-tested design patterns for routing traffic in hub-and-spoke architectures.
- References and builds upon architectural insights from external sources, notably Jose Moreno's analysis, to clarify the service's role as a managed SDN forwarding layer rather than a firewall or NVA.