### PR TITLE
Fix broken link to VNRA GA article in updates post

### DIFF
--- a/updates/launched-generally-available-azure-virtual-network-routing-appliance.md
+++ b/updates/launched-generally-available-azure-virtual-network-routing-appliance.md
@@ -23,7 +23,7 @@ Because it runs on specialised hardware rather than general-purpose VMs, you get
 
 The official announcement is here: [Generally Available: Azure Virtual Network routing appliance](https://azure.microsoft.com/updates?id=568605). The how-to guide is on Microsoft Learn: [Create a Routing Appliance - Azure Virtual Network](https://learn.microsoft.com/en-us/azure/virtual-network/how-to-create-virtual-network-routing-appliance).
 
-If you want the longer version, I wrote up a fuller take on what changed at GA, where it fits in a hub design, and why I still would not use it for internet egress in [Azure Virtual Network Routing Appliance goes GA](/blog/azure-virtual-network-routing-appliance-ga).
+If you want the longer version, I wrote up a fuller take on what changed at GA, where it fits in a hub design, and why I still would not use it for internet egress in [Azure Virtual Network Routing Appliance goes GA](/azure-virtual-network-routing-appliance-ga).
 
 ## Who should care
 


### PR DESCRIPTION
## Why
The update post links to the long-form VNRA GA article using `/blog/...`, but this site serves blog post routes from `/`. That makes the current link resolve to a missing page.

## What changed
I updated the internal link in `updates/launched-generally-available-azure-virtual-network-routing-appliance.md` from:
- `/blog/azure-virtual-network-routing-appliance-ga`
to:
- `/azure-virtual-network-routing-appliance-ga`

## Notes
This is a single-link content fix with no behaviour change outside correcting that route.