### PR TITLE
Update Simon's author bio

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -2,7 +2,11 @@ simonpainter:
   name: Simon Painter
   title: Cloud Network Architect - Microsoft MVP
   image_url: https://github.com/SimonPainter.png
-  description: Simon Painter is a seasoned Cloud Network Architect with over two decades of experience designing and implementing enterprise-scale cloud and network infrastructure solutions. With a strong background in technology, retail, and finance, he specialises in multi-cloud networking, hybrid connectivity, and infrastructure automation. Simon has played a key role in large-scale cloud transformations, security initiatives, and network modernisation strategies, helping organisations build resilient, high-performance cloud architectures. Beyond his technical expertise, Simon enjoys making things—whether through 3D printing, building intricate Lego creations, or exploring new technologies. Based in Yorkshire, he shares his life with his wife, three children, and their spaniel, Mabel. Passionate about problem-solving and innovation, he shares insights on cloud networking, automation, and security.
+  description: Simon Painter is a seasoned Cloud Network Architect with over two decades of experience designing and implementing enterprise-scale cloud and network infrastructure solutions. He has led cloud and datacentre migrations, large network mergers and divestitures, and major modernisation programmes across technology, retail, and finance. His work spans multi-cloud networking, hybrid connectivity, infrastructure automation, and security, and he has helped organisations build resilient, high-performance architectures at scale.
+  
+  Simon is a two-time Microsoft Most Valuable Professional, recognised for both Azure networking and on-premises networking. He is also an AWS certification subject matter expert for Advanced Networking, with deep experience supporting teams through complex platform change and operational transformation.
+  
+  Beyond his technical work, Simon enjoys making things through 3D printing, building intricate Lego creations, and exploring new technologies. Based in Yorkshire, he shares his life with his wife, three children, and their spaniel, Mabel. He writes about cloud networking, automation, security, and the lessons learned from real-world infrastructure programmes.
   socials:
     github: SimonPainter
     linkedin: sipainter

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -2,11 +2,12 @@ simonpainter:
   name: Simon Painter
   title: Cloud Network Architect - Microsoft MVP
   image_url: https://github.com/SimonPainter.png
-  description: Simon Painter is a seasoned Cloud Network Architect with over two decades of experience designing and implementing enterprise-scale cloud and network infrastructure solutions. He has led cloud and datacentre migrations, large network mergers and divestitures, and major modernisation programmes across technology, retail, and finance. His work spans multi-cloud networking, hybrid connectivity, infrastructure automation, and security, and he has helped organisations build resilient, high-performance architectures at scale.
-  
-  Simon is a two-time Microsoft Most Valuable Professional, recognised for both Azure networking and on-premises networking. He is also an AWS certification subject matter expert for Advanced Networking, with deep experience supporting teams through complex platform change and operational transformation.
-  
-  Beyond his technical work, Simon enjoys making things through 3D printing, building intricate Lego creations, and exploring new technologies. Based in Yorkshire, he shares his life with his wife, three children, and their spaniel, Mabel. He writes about cloud networking, automation, security, and the lessons learned from real-world infrastructure programmes.
+  description: |
+    Simon Painter is a seasoned Cloud Network Architect with over two decades of experience designing and implementing enterprise-scale cloud and network infrastructure solutions. He has led cloud and datacentre migrations, large network mergers and divestitures, and major modernisation programmes across technology, retail, and finance. His work spans multi-cloud networking, hybrid connectivity, infrastructure automation, and security, and he has helped organisations build resilient, high-performance architectures at scale.
+
+    Simon is a two-time Microsoft Most Valuable Professional, recognised for both Azure networking and on-premises networking. He is also an AWS certification subject matter expert for Advanced Networking, with deep experience supporting teams through complex platform change and operational transformation.
+
+    Beyond his technical work, Simon enjoys making things through 3D printing, building intricate Lego creations, and exploring new technologies. Based in Yorkshire, he shares his life with his wife, three children, and their spaniel, Mabel. He writes about cloud networking, automation, security, and the lessons learned from real-world infrastructure programmes.
   socials:
     github: SimonPainter
     linkedin: sipainter

--- a/updates/authors.yml
+++ b/updates/authors.yml
@@ -2,7 +2,11 @@ simonpainter:
   name: Simon Painter
   title: Cloud Network Architect - Microsoft MVP
   image_url: https://github.com/SimonPainter.png
-  description: Simon Painter is a seasoned Cloud Network Architect with over two decades of experience designing and implementing enterprise-scale cloud and network infrastructure solutions. With a strong background in technology, retail, and finance, he specialises in multi-cloud networking, hybrid connectivity, and infrastructure automation. Simon has played a key role in large-scale cloud transformations, security initiatives, and network modernisation strategies, helping organisations build resilient, high-performance cloud architectures. Beyond his technical expertise, Simon enjoys making things—whether through 3D printing, building intricate Lego creations, or exploring new technologies. Based in Yorkshire, he shares his life with his wife, three children, and their spaniel, Mabel. Passionate about problem-solving and innovation, he shares insights on cloud networking, automation, and security.
+  description: Simon Painter is a seasoned Cloud Network Architect with over two decades of experience designing and implementing enterprise-scale cloud and network infrastructure solutions. He has led cloud and datacentre migrations, large network mergers and divestitures, and major modernisation programmes across technology, retail, and finance. His work spans multi-cloud networking, hybrid connectivity, infrastructure automation, and security, and he has helped organisations build resilient, high-performance architectures at scale.
+  
+  Simon is a two-time Microsoft Most Valuable Professional, recognised for both Azure networking and on-premises networking. He is also an AWS certification subject matter expert for Advanced Networking, with deep experience supporting teams through complex platform change and operational transformation.
+  
+  Beyond his technical work, Simon enjoys making things through 3D printing, building intricate Lego creations, and exploring new technologies. Based in Yorkshire, he shares his life with his wife, three children, and their spaniel, Mabel. He writes about cloud networking, automation, security, and the lessons learned from real-world infrastructure programmes.
   socials:
     github: SimonPainter
     linkedin: sipainter

--- a/updates/authors.yml
+++ b/updates/authors.yml
@@ -2,11 +2,12 @@ simonpainter:
   name: Simon Painter
   title: Cloud Network Architect - Microsoft MVP
   image_url: https://github.com/SimonPainter.png
-  description: Simon Painter is a seasoned Cloud Network Architect with over two decades of experience designing and implementing enterprise-scale cloud and network infrastructure solutions. He has led cloud and datacentre migrations, large network mergers and divestitures, and major modernisation programmes across technology, retail, and finance. His work spans multi-cloud networking, hybrid connectivity, infrastructure automation, and security, and he has helped organisations build resilient, high-performance architectures at scale.
-  
-  Simon is a two-time Microsoft Most Valuable Professional, recognised for both Azure networking and on-premises networking. He is also an AWS certification subject matter expert for Advanced Networking, with deep experience supporting teams through complex platform change and operational transformation.
-  
-  Beyond his technical work, Simon enjoys making things through 3D printing, building intricate Lego creations, and exploring new technologies. Based in Yorkshire, he shares his life with his wife, three children, and their spaniel, Mabel. He writes about cloud networking, automation, security, and the lessons learned from real-world infrastructure programmes.
+  description: |
+    Simon Painter is a seasoned Cloud Network Architect with over two decades of experience designing and implementing enterprise-scale cloud and network infrastructure solutions. He has led cloud and datacentre migrations, large network mergers and divestitures, and major modernisation programmes across technology, retail, and finance. His work spans multi-cloud networking, hybrid connectivity, infrastructure automation, and security, and he has helped organisations build resilient, high-performance architectures at scale.
+
+    Simon is a two-time Microsoft Most Valuable Professional, recognised for both Azure networking and on-premises networking. He is also an AWS certification subject matter expert for Advanced Networking, with deep experience supporting teams through complex platform change and operational transformation.
+
+    Beyond his technical work, Simon enjoys making things through 3D printing, building intricate Lego creations, and exploring new technologies. Based in Yorkshire, he shares his life with his wife, three children, and their spaniel, Mabel. He writes about cloud networking, automation, security, and the lessons learned from real-world infrastructure programmes.
   socials:
     github: SimonPainter
     linkedin: sipainter


### PR DESCRIPTION
## Why
The author bio needed a clearer, stronger summary of Simon's background and achievements.

## What changed
- Broke the bio into shorter paragraphs for easier reading.
- Removed em dashes and tightened the wording.
- Added the missing professional highlights: cloud and datacentre migrations, large network mergers and divestitures, two MVP awards for Azure networking and on-premises networking, and AWS Advanced Networking SME experience.

## Notes
- The same bio text was updated in both author metadata files so the site stays consistent across blog and updates content.