### PR TITLE
Fix mobile nav menu hidden by backdrop-filter stacking context

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -280,9 +280,28 @@ pre code {
 
 /* ===== NAVBAR & FOOTER ===== */
 
-/* Navbar styling */
+/* Navbar styling — use a pseudo-element for the blur so the navbar itself
+   doesn't create a stacking context that traps the mobile sidebar */
 .navbar {
+  position: relative;
+}
+
+.navbar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
   backdrop-filter: blur(8px);
+  z-index: -1;
+  pointer-events: none;
+}
+
+/* Mobile sidebar — ensure it sits above the navbar's stacking context */
+.navbar-sidebar {
+  z-index: calc(var(--ifm-z-index-overlay) + 1);
+}
+
+.navbar-sidebar__backdrop {
+  z-index: var(--ifm-z-index-overlay);
 }
 
 .navbar__brand {


### PR DESCRIPTION
The mobile hamburger menu appeared to open (the icon changed to an X) but the nav links were never visible. Tapping the three lines did nothing useful from the user's perspective.

The root cause was `backdrop-filter: blur(8px)` applied directly to `.navbar`. In CSS, `backdrop-filter` creates a new stacking context, which scopes any child element's `z-index` to within that context. Because Docusaurus renders `.navbar-sidebar` as a child of `.navbar`, the sidebar could never escape the navbar's stacking layer -- it was effectively invisible behind the page content.

The fix moves the blur to a `::before` pseudo-element on `.navbar`. This preserves the frosted-glass visual effect while keeping `.navbar` itself free of a stacking context. Two explicit `z-index` rules are also added for `.navbar-sidebar` and `.navbar-sidebar__backdrop` as extra insurance.