### PR TITLE
Add brief note on Cloudflare redirect permission mapping

### DIFF
--- a/blog/cloudflare-redirect-permissions.md
+++ b/blog/cloudflare-redirect-permissions.md
@@ -10,6 +10,8 @@ date: 2026-08-13
 
 I hit a Cloudflare authorisation error while creating a redirect ruleset in Terraform. The error was correct: the token did not have enough rights.
 
+<!-- truncate -->
+
 The confusing part was not the error itself. It was finding which permission was missing. I had `Zone -> DNS -> Edit` and other zone permissions that looked right for a zone `cloudflare_ruleset` with `phase = "http_request_dynamic_redirect"`, but apply still failed.
 
 This was the anonymised error:

--- a/blog/cloudflare-redirect-permissions.md
+++ b/blog/cloudflare-redirect-permissions.md
@@ -1,0 +1,36 @@
+---
+title: "Cloudflare redirect ruleset auth error: the permission I couldn't find"
+authors: simonpainter
+tags:
+  - terraform
+  - troubleshooting
+  - dns
+date: 2026-08-13
+---
+
+I hit a Cloudflare authorisation error while creating a redirect ruleset in Terraform. The error was correct: the token did not have enough rights.
+
+The confusing part was not the error itself. It was finding which permission was missing. I had `Zone -> DNS -> Edit` and other zone permissions that looked right for a zone `cloudflare_ruleset` with `phase = "http_request_dynamic_redirect"`, but apply still failed.
+
+This was the anonymised error:
+
+```text
+Error: failed to make http request with cloudflare_ruleset.redirect_www on zone.tf line 45, in resource "cloudflare_ruleset" "redirect_www":
+
+resource "cloudflare_ruleset" "redirect_www" {
+
+POST "https://api.cloudflare.com/client/v4/zones/<zone_id>/rulesets":
+403 Forbidden {"success":false,"errors":[{"code":10000,"message":"Authentication error"}],"messages":[],"result":null}
+```
+
+The missing permission was:
+
+- `Account -> Bulk URL Redirects -> Edit`
+
+That took longer than expected to find, because I expected a Single Redirects or Page Rules style permission. The useful takeaway is that Cloudflare permission names do not always map neatly to the Terraform resource name or scope.
+
+Useful docs:
+
+- [Create a redirect rule using Terraform](https://developers.cloudflare.com/rules/url-forwarding/single-redirects/terraform-example/)
+- [Create Bulk Redirects via API](https://developers.cloudflare.com/rules/url-forwarding/bulk-redirects/create-api/)
+- [API token permissions](https://developers.cloudflare.com/fundamentals/api/reference/permissions/)


### PR DESCRIPTION
## Why
I hit a real Cloudflare authorisation failure while creating a redirect ruleset with Terraform. The hard part was not the 403 itself, it was finding the exact missing permission because the expected permission names did not clearly match the resource I was applying.

## What changed
This adds a short blog post documenting the issue and the fix:
- captures an anonymised version of the Terraform/Cloudflare 403 error
- explains that a zone-scoped `cloudflare_ruleset` using `http_request_dynamic_redirect` still required account-scoped permission
- calls out the exact permission required: `Account -> Bulk URL Redirects -> Edit`
- links to relevant Cloudflare documentation for Terraform redirects, Bulk Redirects API, and token permissions

## Notes for reviewers
The post is intentionally brief and focused on permission discoverability rather than Terraform syntax troubleshooting.